### PR TITLE
feat: wire CMS singletons and collections to community and music pages

### DIFF
--- a/keystatic.config.ts
+++ b/keystatic.config.ts
@@ -30,7 +30,7 @@ export default config({
             title: fields.text({ label: "Title" }),
             body: fields.text({ label: "Body", multiline: true }),
           }),
-          { label: "Gear cards", itemLabel: (props) => props.fields.title.value }
+          { label: "Gear cards", itemLabel: (props) => props.fields.title.value ?? "" }
         ),
       },
     }),
@@ -61,7 +61,7 @@ export default config({
         location: fields.text({ label: "Location", description: 'e.g. "Phoenix"' }),
         specialties: fields.array(fields.text({ label: "Specialty" }), {
           label: "Specialties",
-          itemLabel: (props) => props.fields.value.value,
+          itemLabel: (props) => props.value ?? "",
         }),
         bio: fields.text({ label: "Bio", multiline: true, validation: { isRequired: false } }),
         photo: fields.image({
@@ -114,7 +114,7 @@ export default config({
         bio: fields.text({ label: "Bio", multiline: true }),
         style: fields.array(fields.text({ label: "Style tag" }), {
           label: "Style tags",
-          itemLabel: (props) => props.fields.value.value,
+          itemLabel: (props) => props.value ?? "",
         }),
         resident: fields.checkbox({ label: "Resident DJ", defaultValue: false }),
         photo: fields.image({

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -12,8 +12,8 @@ const instructors = defineCollection({
   type: "data",
   schema: z.object({
     name: z.string(),
-    level: z.string(),
-    location: z.string(),
+    level: z.string().optional(),
+    location: z.string().optional(),
     specialties: z.array(z.string()).default([]),
     bio: z.string().optional(),
     photo: z.string().optional(),
@@ -26,9 +26,9 @@ const venues = defineCollection({
   type: "data",
   schema: z.object({
     name: z.string(),
-    neighborhood: z.string(),
-    floor: z.string(),
-    notes: z.string(),
+    neighborhood: z.string().optional(),
+    floor: z.string().optional(),
+    notes: z.string().optional(),
     website: z.string().url().optional(),
     mapUrl: z.string().url().optional(),
   }),
@@ -38,9 +38,9 @@ const resources = defineCollection({
   type: "data",
   schema: z.object({
     name: z.string(),
-    type: z.string(),
-    description: z.string(),
-    url: z.string().url(),
+    type: z.string().optional(),
+    description: z.string().optional(),
+    url: z.string().url().optional(),
   }),
 });
 
@@ -48,9 +48,9 @@ const djs = defineCollection({
   type: "data",
   schema: z.object({
     name: z.string(),
-    handle: z.string(),
-    realName: z.string(),
-    bio: z.string(),
+    handle: z.string().optional(),
+    realName: z.string().optional(),
+    bio: z.string().optional(),
     style: z.array(z.string()).default([]),
     resident: z.boolean().default(false),
     photo: z.string().optional(),

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -60,4 +60,23 @@ const djs = defineCollection({
   }),
 });
 
-export const collections = { posts, instructors, venues, resources, djs };
+// Singleton page copy — written by Keystatic to src/content/pages/*.yaml
+const pages = defineCollection({
+  type: "data",
+  schema: z.object({
+    // Community page
+    instructorsIntro: z.string().optional(),
+    venuesIntro: z.string().optional(),
+    resourcesIntro: z.string().optional(),
+    gearIntro: z.string().optional(),
+    gearCards: z.array(z.object({ title: z.string(), body: z.string() })).optional(),
+    // Music page
+    approachText: z.string().optional(),
+    philosophyText: z.string().optional(),
+    manifestoLine: z.string().optional(),
+    manifestoSubline: z.string().optional(),
+    playlistsIntro: z.string().optional(),
+  }),
+});
+
+export const collections = { posts, instructors, venues, resources, djs, pages };

--- a/src/pages/community.astro
+++ b/src/pages/community.astro
@@ -1,7 +1,7 @@
 ---
 import Layout from "../layouts/Layout.astro";
 import { generateOrganizationSchema } from "../lib/schema";
-import { getCollection } from "astro:content";
+import { getCollection, getEntry } from "astro:content";
 
 const schema = generateOrganizationSchema();
 
@@ -25,13 +25,30 @@ const DUMMY_RESOURCES = [
   { name: "WSDC", type: "Governing Body", description: "West Coast Swing Dance Council — official points registry for competitive dancers.", url: "#" },
 ];
 
-const instructorEntries = await getCollection("instructors");
-const venueEntries = await getCollection("venues");
-const resourceEntries = await getCollection("resources");
+const DUMMY_GEAR_CARDS = [
+  { title: "Shoes", body: "Suede-soled dance shoes are the standard. Look for low heels with a flexible sole. Popular brands include Very Fine, Ray Rose, and Freed of London. Budget pick: any suede-soled Latin shoe." },
+  { title: "Floor Prep", body: "Most Phoenix venues have hardwood or tile. Bring a sole brush to keep your suede clean. Avoid dancing on rubber-soled shoes — your knees will thank you." },
+  { title: "Where to Shop", body: "Discount Dance Supply and Dance Naturals carry WCS-appropriate shoes online. Locally, check with instructors — some carry inventory or can point you to current deals." },
+];
+
+const [instructorEntries, venueEntries, resourceEntries, pageEntry] = await Promise.all([
+  getCollection("instructors"),
+  getCollection("venues"),
+  getCollection("resources"),
+  getEntry("pages", "community"),
+]);
 
 const instructors = instructorEntries.length > 0 ? instructorEntries.map((e) => e.data) : DUMMY_INSTRUCTORS;
 const venues = venueEntries.length > 0 ? venueEntries.map((e) => e.data) : DUMMY_VENUES;
 const resources = resourceEntries.length > 0 ? resourceEntries.map((e) => e.data) : DUMMY_RESOURCES;
+
+const copy = {
+  instructorsIntro: pageEntry?.data.instructorsIntro ?? "Arizona has a deep bench of talent. These are some of the local instructors worth knowing.",
+  venuesIntro: pageEntry?.data.venuesIntro ?? "Places to dance in and around the Phoenix metro.",
+  resourcesIntro: pageEntry?.data.resourcesIntro ?? "Key events, organizations, and platforms in the Arizona and national WCS world.",
+  gearIntro: pageEntry?.data.gearIntro ?? "New to WCS or just looking to upgrade? Here's what to know.",
+  gearCards: pageEntry?.data.gearCards?.length ? pageEntry.data.gearCards : DUMMY_GEAR_CARDS,
+};
 ---
 
 <Layout
@@ -48,10 +65,7 @@ const resources = resourceEntries.length > 0 ? resourceEntries.map((e) => e.data
 
       <section class="content-section">
         <h2 class="section-title">> Local Instructors</h2>
-        <p class="section-intro">
-          Arizona has a deep bench of talent. These are some of the local
-          instructors worth knowing.
-        </p>
+        <p class="section-intro">{copy.instructorsIntro}</p>
         <div class="cards-grid">
           {
             instructors.map((instructor) => (
@@ -74,9 +88,7 @@ const resources = resourceEntries.length > 0 ? resourceEntries.map((e) => e.data
 
       <section class="content-section">
         <h2 class="section-title">> Local Venues</h2>
-        <p class="section-intro">
-          Places to dance in and around the Phoenix metro.
-        </p>
+        <p class="section-intro">{copy.venuesIntro}</p>
         <div class="cards-grid">
           {
             venues.map((venue) => (
@@ -95,10 +107,7 @@ const resources = resourceEntries.length > 0 ? resourceEntries.map((e) => e.data
 
       <section class="content-section">
         <h2 class="section-title">> WCS Resources</h2>
-        <p class="section-intro">
-          Key events, organizations, and platforms in the Arizona and national
-          WCS world.
-        </p>
+        <p class="section-intro">{copy.resourcesIntro}</p>
         <div class="resource-list">
           {
             resources.map((resource) => (
@@ -116,34 +125,14 @@ const resources = resourceEntries.length > 0 ? resourceEntries.map((e) => e.data
 
       <section class="content-section">
         <h2 class="section-title">> Gear Up</h2>
-        <p class="section-intro">
-          New to WCS or just looking to upgrade? Here's what to know.
-        </p>
+        <p class="section-intro">{copy.gearIntro}</p>
         <div class="gear-grid">
-          <div class="card gear-card">
-            <h3>Shoes</h3>
-            <p>
-              Suede-soled dance shoes are the standard. Look for low heels with
-              a flexible sole. Popular brands include Very Fine, Ray Rose, and
-              Freed of London. Budget pick: any suede-soled Latin shoe.
-            </p>
-          </div>
-          <div class="card gear-card">
-            <h3>Floor Prep</h3>
-            <p>
-              Most Phoenix venues have hardwood or tile. Bring a sole brush to
-              keep your suede clean. Avoid dancing on rubber-soled shoes — your
-              knees will thank you.
-            </p>
-          </div>
-          <div class="card gear-card">
-            <h3>Where to Shop</h3>
-            <p>
-              Discount Dance Supply and Dance Naturals carry WCS-appropriate
-              shoes online. Locally, check with instructors — some carry
-              inventory or can point you to current deals.
-            </p>
-          </div>
+          {copy.gearCards.map((card) => (
+            <div class="card gear-card">
+              <h3>{card.title}</h3>
+              <p>{card.body}</p>
+            </div>
+          ))}
         </div>
       </section>
     </div>

--- a/src/pages/music.astro
+++ b/src/pages/music.astro
@@ -1,7 +1,7 @@
 ---
 import Layout from "../layouts/Layout.astro";
 import { generateOrganizationSchema } from "../lib/schema";
-import { getCollection } from "astro:content";
+import { getCollection, getEntry } from "astro:content";
 
 const schema = generateOrganizationSchema();
 
@@ -12,8 +12,20 @@ const DUMMY_DJS = [
   { handle: "DJ Static", realName: "Sam T.", bio: "The anchor of early evening sets. Static builds the room up slowly — smooth vocals, laid-back grooves, and just enough tension to pull dancers onto the floor.", style: ["Soul", "Smooth RnB", "Chill Hop"], resident: false },
 ];
 
-const djEntries = await getCollection("djs");
+const [djEntries, pageEntry] = await Promise.all([
+  getCollection("djs"),
+  getEntry("pages", "music"),
+]);
+
 const djs = djEntries.length > 0 ? djEntries.map((e) => e.data) : DUMMY_DJS;
+
+const copy = {
+  approachText: pageEntry?.data.approachText ?? "Music is the reason we're all here. West Coast Swing was built on the idea that great dancing follows great music — not the other way around. We take that seriously.\n\nEvery White Rabbit event is curated, not shuffled. Our DJs don't just play songs; they build sets with intention, reading the room and shaping the energy of the night from the first note to the last.",
+  philosophyText: pageEntry?.data.philosophyText ?? "We play music that moves people — literally. That means staying contemporary without chasing trends, honoring the roots of WCS while staying open to where music is going. Neo-soul, indie electronic, modern RnB, left-field pop. Anything that hits the right pocket.\n\nThe tempo sweet spot we live in: 110–128 BPM. Wide enough for expression, tight enough to dance.",
+  manifestoLine: pageEntry?.data.manifestoLine ?? "IF IT GROOVES, IT QUALIFIES.",
+  manifestoSubline: pageEntry?.data.manifestoSubline ?? "Genre is a suggestion. Phrasing is law.",
+  playlistsIntro: pageEntry?.data.playlistsIntro ?? "Curated sets for home listening, practice, and late-night winding down. Full streaming links coming soon.",
+};
 
 const playlists = [
   {
@@ -57,39 +69,17 @@ const playlists = [
         <div class="philosophy-grid">
           <div class="philosophy-block">
             <h2 class="section-title">> Our Approach</h2>
-            <p>
-              Music is the reason we're all here. West Coast Swing was built on
-              the idea that great dancing follows great music — not the other way
-              around. We take that seriously.
-            </p>
-            <p>
-              Every White Rabbit event is curated, not shuffled. Our DJs don't
-              just play songs; they build sets with intention, reading the room
-              and shaping the energy of the night from the first note to the
-              last.
-            </p>
+            {copy.approachText.split("\n\n").map((p) => <p>{p}</p>)}
           </div>
           <div class="philosophy-block">
             <h2 class="section-title">> The Philosophy</h2>
-            <p>
-              We play music that moves people — literally. That means staying
-              contemporary without chasing trends, honoring the roots of WCS
-              while staying open to where music is going. Neo-soul, indie
-              electronic, modern RnB, left-field pop. Anything that hits the
-              right pocket.
-            </p>
-            <p>
-              The tempo sweet spot we live in: 110–128 BPM. Wide enough for
-              expression, tight enough to dance.
-            </p>
+            {copy.philosophyText.split("\n\n").map((p) => <p>{p}</p>)}
           </div>
         </div>
 
         <div class="manifesto-block">
-          <div class="manifesto-line">IF IT GROOVES, IT QUALIFIES.</div>
-          <div class="manifesto-line secondary">
-            Genre is a suggestion. Phrasing is law.
-          </div>
+          <div class="manifesto-line">{copy.manifestoLine}</div>
+          <div class="manifesto-line secondary">{copy.manifestoSubline}</div>
         </div>
       </section>
 
@@ -127,8 +117,7 @@ const playlists = [
       <section class="playlist-section">
         <h2 class="section-title">> Playlists</h2>
         <p class="section-intro">
-          Curated sets for home listening, practice, and late-night winding
-          down. Full streaming links coming soon.
+          {copy.playlistsIntro}
         </p>
         <div class="playlist-list">
           {


### PR DESCRIPTION
## Summary

- Community and music pages now pull from Keystatic collections and singletons
- All data falls back to existing dummy content when CMS fields are empty — no visual change until real content is entered
- Fixes TS errors in `keystatic.config.ts` (`itemLabel` props type)

## What's wired up

**Community page**
- Instructors, venues, resources → `getCollection()`
- Section intros, gear cards → `pages/community` singleton via `getEntry()`

**Music page**
- DJs → `getCollection()`
- Approach text, philosophy text, manifesto lines, playlists intro → `pages/music` singleton via `getEntry()`

## How fallbacks work
`??` operator on every field: if Keystatic hasn't written the file yet, the default copy shows. Once content is saved via `/keystatic`, it takes over on next deploy.