### PR TITLE
feat: CSS-only hero image carousel

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,8 +2,11 @@
 import Layout from "../layouts/Layout.astro";
 import RecentPosts from "../components/RecentPosts.astro";
 import { generateOrganizationSchema } from "../lib/schema";
+import { getEntry } from "astro:content";
 
 const schema = generateOrganizationSchema();
+const homeData = await getEntry("pages", "home");
+const heroImages = homeData?.data.heroImages?.filter((i) => i.image) ?? [];
 ---
 
 <Layout
@@ -13,7 +16,19 @@ const schema = generateOrganizationSchema();
 >
   <main>
     <section class="hero">
-      <div class="container">
+      {heroImages.length > 0 && (
+        <div class="hero-slider" style={`--quantity: ${heroImages.length}; --duration: ${heroImages.length * 8}s;`}>
+          <ul class="slider-list">
+            {heroImages.map((item, i) => (
+              <li class="slider-item" style={`--position: ${i + 1};`}>
+                <img src={item.image} alt={item.alt ?? ""} />
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      <div class="hero-overlay" />
+      <div class="container hero-content">
         <h1 class="title gradient-text">THE WHITE RABBIT SOCIETY</h1>
         <p class="tagline">Arizona WCS</p>
         <div class="typed-text" id="typed-text"></div>
@@ -67,13 +82,74 @@ const schema = generateOrganizationSchema();
 
 <style>
   .hero {
-    min-height: 80vh;
+    --width: 600px;
+    --height: 80vh;
+    min-height: var(--height);
     display: flex;
     align-items: center;
     justify-content: center;
     text-align: center;
     position: relative;
     overflow: hidden;
+  }
+
+  .hero-slider {
+    position: absolute;
+    inset: 0;
+    height: var(--height);
+    overflow: hidden;
+    mask-image: linear-gradient(to right, transparent, #000 10% 90%, transparent);
+    z-index: 0;
+  }
+
+  .slider-list {
+    min-width: calc(var(--width) * var(--quantity));
+    position: relative;
+    height: 100%;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .slider-item {
+    width: var(--width);
+    height: 100%;
+    position: absolute;
+    left: 100%;
+    animation: autoRun var(--duration) linear infinite;
+    animation-delay: calc(
+      (var(--duration) / var(--quantity)) * (var(--position) - 1) - var(--duration)
+    );
+  }
+
+  .slider-item img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    object-position: center;
+    opacity: 0.35;
+  }
+
+  .hero-overlay {
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(
+      to bottom,
+      transparent 0%,
+      var(--bg-primary) 100%
+    );
+    pointer-events: none;
+    z-index: 1;
+  }
+
+  @keyframes autoRun {
+    from { left: 100%; }
+    to { left: calc(var(--width) * -1); }
+  }
+
+  .hero-content {
+    position: relative;
+    z-index: 2;
   }
 
   .title {
@@ -127,7 +203,9 @@ const schema = generateOrganizationSchema();
 
   #typed-text-2 {
     min-height: unset;
-    margin-bottom: 3.5rem;
+    margin-bottom: 3rem;
+    color: var(--text-secondary);
+    line-height: 1.8;
   }
 
   .cta-buttons {
@@ -203,12 +281,8 @@ const schema = generateOrganizationSchema();
   }
 
   @keyframes float {
-    0% {
-      transform: translate(0, 0);
-    }
-    100% {
-      transform: translate(50px, 50px);
-    }
+    0% { transform: translate(0, 0); }
+    100% { transform: translate(50px, 50px); }
   }
 
   @media (max-width: 768px) {


### PR DESCRIPTION
## Summary

- Adds a horizontally scrolling photo carousel behind the hero section on the homepage
- Pure CSS — no JavaScript, no libraries
- Images sourced from the Keystatic **Home page** singleton (`heroImages` field)
- Carousel only renders when images have been uploaded — no visual change on empty

## How it works

Uses staggered CSS `animation-delay` per item to create a seamless infinite scroll from right to left. Speed scales with the number of images (`8s × count`).

## Details

- Images render at `opacity: 0.35` so hero text stays readable
- Gradient overlay fades images out at left/right edges and bottom
- Z-index layering keeps buttons and text fully interactive above the carousel
- Falls back gracefully (no carousel) if no images uploaded yet in Keystatic

Closes #4