### PR TITLE
docs: update README and CLAUDE.md for Keystatic CMS

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,41 @@ The environment variable `PUBLIC_GOOGLE_CALENDAR_ID` is required to run the fetc
 
 `src/pages/[filter].astro` generates static city-filtered event pages (e.g. `/phoenix`, `/tucson`) via `getStaticPaths()`. Adding a new city requires adding a new entry there.
 
+### CMS (Keystatic)
+
+Non-technical editors manage content at `/keystatic`. Uses Git-based storage — edits create commits directly to the repo via GitHub OAuth.
+
+- **Local dev**: uses `local` storage mode (reads/writes files directly)
+- **Production**: uses `github` storage mode (commits via GitHub API); requires a GitHub App installed on the repo
+- **Config**: `keystatic.config.ts` — uses `import.meta.env.PROD` to switch storage modes (not `process.env`, which is unavailable in the browser bundle)
+
+Collections (stored as JSON in `src/content/`):
+
+| Collection | Path | Fields |
+|---|---|---|
+| Instructors | `src/content/instructors/` | name, level, location, specialties, bio, photo, website, instagram |
+| Venues | `src/content/venues/` | name, neighborhood, floor, notes, website, mapUrl |
+| Resources | `src/content/resources/` | name, type, description, url |
+| DJs | `src/content/djs/` | name, handle, realName, bio, style, resident, photo, mixcloud, soundcloud, instagram |
+
+Singletons (stored as JSON in `src/content/pages/`):
+
+| Singleton | File | Fields |
+|---|---|---|
+| Home page | `src/content/pages/home.json` | heroImages (image + alt array) |
+| Community page | `src/content/pages/community.json` | instructorsIntro, venuesIntro, resourcesIntro, gearIntro, gearCards |
+| Music page | `src/content/pages/music.json` | approachText, philosophyText, manifestoLine, manifestoSubline, playlistsIntro |
+
+Pages read CMS data via `getCollection()` / `getEntry()` from `astro:content` and fall back to hardcoded dummy data when collections are empty — partial or missing entries never break the build.
+
+Required env vars for production Keystatic (set via `wrangler secret put`):
+- `KEYSTATIC_GITHUB_CLIENT_ID`
+- `KEYSTATIC_GITHUB_CLIENT_SECRET`
+- `KEYSTATIC_SECRET`
+- `PUBLIC_KEYSTATIC_GITHUB_APP_SLUG`
+
+`wrangler.jsonc` must include a `SESSION` KV namespace binding for Keystatic's auth session handling.
+
 ### Content Posts
 
 Markdown posts live in `src/content/posts/` and are managed via Astro Content Collections with Zod schema validation. Filename convention: `YYYY-MM-DD-slug.md`. Non-technical contributors add posts via the GitHub web UI (documented in `POSTS_GUIDE.md`).
@@ -57,6 +92,8 @@ Markdown posts live in `src/content/posts/` and are managed via Astro Content Co
 | `src/layouts/Layout.astro` | Root layout wrapping all pages |
 | `scripts/fetch-calendar.js` | iCal → JSON pipeline |
 | `src/data/events.json` | Pre-generated event data (source of truth at build time) |
+| `keystatic.config.ts` | Keystatic CMS schema — collections and singletons |
+| `src/content/pages/` | Singleton CMS data (home, community, music page copy) |
 
 ### CI / Automated Refresh
 

--- a/README.md
+++ b/README.md
@@ -1,199 +1,72 @@
-# White Rabbit - Phoenix WCS Community
+# The White Rabbit Society
 
-> Follow the white rabbit into Phoenix's West Coast Swing scene.
+Arizona's West Coast Swing community site. Find events, meet local instructors and DJs, and follow the white rabbit.
 
-A modern website for the West Coast Swing (WCS) dance community in Phoenix, Arizona. Find events, connect with dancers, and discover your flow.
-
-🌐 **Live Site:** [whiterabbitwcs.com](https://whiterabbitwcs.com)
+**Live site**: [whiterabbitwcs.com](https://whiterabbitwcs.com)
 
 ---
 
-## ✨ Features
+## Stack
 
-### 🗓️ Event Calendar
-- Google Calendar integration for real-time event updates
-- Filter by event type (socials, workshops, competitions)
-- Event cards with detailed modals
-- Server-rendered for fresh data on every visit
+- **Framework**: Astro 5 (static output, Cloudflare Workers adapter)
+- **CMS**: Keystatic (Git-based, admin UI at `/keystatic`)
+- **Deployment**: Cloudflare Workers (auto-deploys on push to `main`)
+- **Package manager**: pnpm
 
-### 📝 Community Posts
-- Latest updates and announcements on homepage
-- Markdown-powered content
-- Easy contribution via GitHub (see [POSTS_GUIDE.md](./POSTS_GUIDE.md))
-
-### 🎨 Matrix-Themed Design
-- Custom Matrix-inspired aesthetic
-- Multiple theme moodboards
-- Theme switcher component
-- Fully responsive, mobile-first design
-
-### 🚀 SEO Optimized
-- Comprehensive meta tags (Open Graph, Twitter Cards)
-- Structured data (JSON-LD) for events and organization
-- Automatic sitemap generation
-- Local SEO optimization for Phoenix, AZ
-
-### 📱 Modern Stack
-- Built with [Astro 5](https://astro.build)
-- Deployed on [Cloudflare Workers](https://workers.cloudflare.com)
-- Lightning-fast static generation with server-rendered updates
-
----
-
-## 🏗️ Project Structure
-
-```text
-white-rabbit/
-├── public/
-│   ├── favicon.svg
-│   ├── robots.txt
-│   └── moodboards/         # Design inspiration
-├── src/
-│   ├── components/
-│   │   ├── EventCard.astro
-│   │   ├── Navigation.astro
-│   │   ├── RecentPosts.astro
-│   │   ├── SEO.astro
-│   │   └── ThemeSwitcher.astro
-│   ├── content/
-│   │   ├── config.ts       # Content collections config
-│   │   └── posts/          # Blog-style posts
-│   ├── data/
-│   │   └── events.json     # example event dummy data
-│   ├── layouts/
-│   │   └── Layout.astro
-│   ├── lib/
-│   │   ├── calendar.ts     # Google Calendar integration
-│   │   └── schema.ts       # Structured data helpers
-│   ├── pages/
-│   │   ├── about.astro
-│   │   ├── events.astro
-│   │   ├── index.astro
-│   │   └── api/
-│   │       └── debug-calendar.json.ts
-│   ├── styles/
-│   │   └── themes.css
-│   └── env.d.ts            # TypeScript definitions
-├── PLAN.md                 # Project roadmap
-├── POSTS_GUIDE.md          # How to add posts
-└── CALENDAR_SETUP.md       # Calendar integration guide
-```
-
----
-
-## 🛠️ Development
-
-### Prerequisites
-- [Node.js](https://nodejs.org/) 18+
-- [pnpm](https://pnpm.io/)
-
-### Commands
-
-| Command                | Action                                           |
-| :--------------------- | :----------------------------------------------- |
-| `pnpm install`         | Install dependencies                             |
-| `pnpm dev`             | Start local dev server at `localhost:4321`       |
-| `pnpm build`           | Build production site to `./dist/`               |
-| `pnpm preview`         | Preview build locally before deploying           |
-| `pnpm astro ...`       | Run Astro CLI commands                           |
-| `oxlint`               | Lint code (run before committing)                |
-| `oxfmt`                | Format code (run before committing)              |
-
-### Environment Variables
-
-Create a `.dev.vars` file (and set in Cloudflare Workers):
+## Development
 
 ```bash
-PUBLIC_GOOGLE_CALENDAR_ID=your-calendar-id@group.calendar.google.com
+pnpm install
+pnpm dev        # http://localhost:4321
+pnpm build
+pnpm preview
+pnpm lint
+pnpm format
 ```
 
-See [CALENDAR_SETUP.md](./CALENDAR_SETUP.md) for detailed setup instructions.
+Local environment variables go in `.dev.vars` (gitignored):
 
----
+```
+PUBLIC_GOOGLE_CALENDAR_ID=...
+KEYSTATIC_GITHUB_CLIENT_ID=...
+KEYSTATIC_GITHUB_CLIENT_SECRET=...
+KEYSTATIC_SECRET=...
+PUBLIC_KEYSTATIC_GITHUB_APP_SLUG=...
+```
 
-## 📝 Contributing
+## Content Management
 
-### Adding Posts
+Non-technical editors manage content at `/keystatic`. Requires a GitHub account with write access to this repo.
 
-Community members can add announcements and updates by creating markdown files. See [POSTS_GUIDE.md](./POSTS_GUIDE.md) for step-by-step instructions.
+| Collection | Path | Description |
+|---|---|---|
+| Instructors | `src/content/instructors/` | Local instructor profiles |
+| Venues | `src/content/venues/` | Dance venues |
+| Resources | `src/content/resources/` | WCS resources and links |
+| DJs | `src/content/djs/` | DJ profiles |
+| Page copy | `src/content/pages/` | Hero images, community/music section text |
 
-**Quick version:**
-1. Create a file in `src/content/posts/`
-2. Name it: `YYYY-MM-DD-title.md`
-3. Add your content in markdown
-4. Commit and push (or create PR)
+Pages fall back to placeholder content when CMS fields are empty — a partial entry will never break the build.
 
-### Development Workflow
+**Alt text**: Always fill in alt text when uploading images. Describe who/what/where in one sentence. Screen readers and search engines depend on it.
 
-1. Create a feature branch
-2. Make your changes
-3. Run `oxfmt` to format code
-4. Commit with descriptive message
-5. Push and create a pull request
+## Event Calendar
 
----
+Events are pulled from Google Calendar and stored in `src/data/events.json`. A GitHub Actions workflow (`daily-rebuild.yml`) refreshes this daily at 6 AM UTC.
 
-## 🚀 Deployment
+To refresh manually:
+```bash
+PUBLIC_GOOGLE_CALENDAR_ID=xxx node scripts/fetch-calendar.js
+```
 
-The site automatically deploys to Cloudflare Workers when pushing to `main` branch.
+## Adding a City Filter Page
 
-**Production:** https://whiterabbitwcs.com
+Edit `src/pages/[filter].astro` and add a new entry to `getStaticPaths()`.
 
-### Environment Setup (Cloudflare Workers)
+## Posts / Blog
 
-1. Go to your Cloudflare Workers & Pages project
-2. Settings → Variables and Secrets
-3. Add `PUBLIC_GOOGLE_CALENDAR_ID` with your calendar ID
-4. Trigger a new deployment
+Markdown posts live in `src/content/posts/` with filename convention `YYYY-MM-DD-slug.md`. See `POSTS_GUIDE.md` for non-technical contributors.
 
----
+## Deployment
 
-## 📋 Roadmap
-
-See [PLAN.md](./PLAN.md) for the complete feature roadmap.
-
-### ✅ Completed
-- Site structure and navigation
-- Event calendar with Google Calendar integration
-- Posts/announcements system
-- About page
-- Comprehensive SEO
-- Matrix-themed design system
-
-### 🎯 Next Up
-- Venues directory
-- Teachers directory
-- Event enhancements (Add to Calendar, detail pages)
-
----
-
-## 🔧 Tech Stack
-
-- **Framework:** [Astro 5](https://astro.build)
-- **Hosting:** [Cloudflare Workers](https://workers.cloudflare.com)
-- **Calendar:** Google Calendar (public iCal feed)
-- **Content:** Astro Content Collections
-- **Styling:** Custom CSS with CSS variables
-- **SEO:** Built-in with structured data
-
----
-
-## 📚 Documentation
-
-- [PLAN.md](./PLAN.md) - Project roadmap and feature planning
-- [POSTS_GUIDE.md](./POSTS_GUIDE.md) - How to add posts to the site
-- [CALENDAR_SETUP.md](./CALENDAR_SETUP.md) - Google Calendar integration setup
-
----
-
-## 🌐 Learn More
-
-- [Astro Documentation](https://docs.astro.build)
-- [Cloudflare Workers Docs](https://developers.cloudflare.com/workers/)
-- [West Coast Swing](https://en.wikipedia.org/wiki/West_Coast_Swing)
-
----
-
-## 📄 License
-
-Built for the Phoenix WCS community. Follow the white rabbit. 🐇
+Cloudflare Workers. Push to `main` triggers an automatic redeploy. Secrets are managed via `wrangler secret put` or the Cloudflare dashboard.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,41 @@ Arizona's West Coast Swing community site. Find events, meet local instructors a
 
 ---
 
+## Features
+
+### Event Calendar
+- Google Calendar integration via public iCal feed
+- Filter by event type (socials, workshops, competitions) and city
+- Event cards with map links (Apple Maps on iOS, Google Maps otherwise)
+- Refreshed daily via GitHub Actions; data stored in `src/data/events.json`
+
+### Community
+- Local instructor and venue directories, managed via Keystatic CMS
+- WCS resources and links
+- Gear guide for new dancers
+
+### Music
+- DJ profiles with Mixcloud/SoundCloud links
+- Philosophy and approach copy, editable in CMS
+
+### Posts / Blog
+- Markdown posts in `src/content/posts/`, filename convention `YYYY-MM-DD-slug.md`
+- Latest posts shown on homepage
+- Non-technical contributors can add posts via the GitHub web UI — see `POSTS_GUIDE.md`
+
+### SEO
+- Comprehensive meta tags (Open Graph, Twitter Cards)
+- Structured data (JSON-LD) for events and organization
+- Automatic sitemap generation
+- Local SEO for Phoenix, Tucson, Prescott, and beyond
+
+### Design
+- Matrix-inspired theme with CSS custom properties (`src/styles/themes.css`)
+- Theme switcher component persists choice to `localStorage`
+- Fully responsive, mobile-first
+
+---
+
 ## Stack
 
 - **Framework**: Astro 5 (static output, Cloudflare Workers adapter)
@@ -62,10 +97,6 @@ PUBLIC_GOOGLE_CALENDAR_ID=xxx node scripts/fetch-calendar.js
 ## Adding a City Filter Page
 
 Edit `src/pages/[filter].astro` and add a new entry to `getStaticPaths()`.
-
-## Posts / Blog
-
-Markdown posts live in `src/content/posts/` with filename convention `YYYY-MM-DD-slug.md`. See `POSTS_GUIDE.md` for non-technical contributors.
 
 ## Deployment
 


### PR DESCRIPTION
## Summary

- Rewrites README from scratch: removes emojis/roadmap/outdated content, adds Keystatic CMS section, updated stack, env vars, and content management table
- Updates CLAUDE.md with a new Keystatic section covering storage modes (local vs github), all 4 collections, 3 singletons, required env vars, and the SESSION KV binding requirement

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Verify CLAUDE.md has accurate field lists matching `keystatic.config.ts`