### PR TITLE
fix: remove gaps between hero carousel images

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -143,7 +143,7 @@ const heroImages = homeData?.data.heroImages?.filter((i) => i.image) ?? [];
   }
 
   @keyframes autoRun {
-    from { left: 100%; }
+    from { left: calc(var(--width) * (var(--quantity) - 1)); }
     to { left: calc(var(--width) * -1); }
   }
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -142,6 +142,8 @@ const heroImages = homeData?.data.heroImages?.filter((i) => i.image) ?? [];
     z-index: 1;
   }
 
+  /* Carousel technique adapted from https://theosoti.com/short/autoplay-carousel/
+     from value uses width*(quantity-1) instead of 100% to keep images gapless at any viewport width */
   @keyframes autoRun {
     from { left: calc(var(--width) * (var(--quantity) - 1)); }
     to { left: calc(var(--width) * -1); }


### PR DESCRIPTION
## Summary

Fixes visible gaps between photos in the hero carousel. `left: 100%` resolved to the full container/viewport width, leaving a gap equal to `viewport_width - image_width` between each photo. Changed the `from` keyframe to `calc(var(--width) * (var(--quantity) - 1))` so images are packed flush.

## Questions for @white-rabbit-wcs

- **Gap or no gap?** This PR removes the spacing between photos so they scroll as a continuous strip. Happy to revert if you prefer the spaced look.
- **Vignette?** Want a dark vignette (soft black fade) around the edges of the carousel to blend the photos into the background? Can add that as a follow-up.