### PR TITLE
feat: add Site Settings singleton to Keystatic for social links

### DIFF
--- a/keystatic.config.ts
+++ b/keystatic.config.ts
@@ -16,6 +16,17 @@ export default config({
   },
 
   singletons: {
+    siteSettings: singleton({
+      label: "Site settings",
+      path: "src/content/pages/site-settings",
+      format: { data: "yaml" },
+      schema: {
+        discordUrl: fields.url({ label: "Discord invite URL", validation: { isRequired: false } }),
+        instagramUrl: fields.url({ label: "Instagram URL", validation: { isRequired: false } }),
+        facebookUrl: fields.url({ label: "Facebook URL", validation: { isRequired: false } }),
+      },
+    }),
+
     homePage: singleton({
       label: "Home page",
       path: "src/content/pages/home",

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,5 +1,10 @@
 ---
+import { getEntry } from "astro:content";
 
+const siteSettings = await getEntry("pages", "site-settings");
+const discordUrl = siteSettings?.data.discordUrl ?? "https://discord.gg/U9BYSrxH";
+const instagramUrl = siteSettings?.data.instagramUrl ?? "https://www.instagram.com/whiterabbit.wcs/";
+const facebookUrl = siteSettings?.data.facebookUrl ?? "https://www.facebook.com/groups/183446960374256";
 ---
 
 <footer class="site-footer">
@@ -10,7 +15,7 @@
     </div>
     <div class="footer-right">
       <a
-        href="https://www.instagram.com/whiterabbit.wcs/"
+        href={instagramUrl}
         class="footer-link"
         aria-label="Visit our Instagram"
         target="_blank"
@@ -19,7 +24,7 @@
         <span class="footer-link-text">Instagram</span>
       </a>
       <a
-        href="https://www.facebook.com/groups/183446960374256"
+        href={facebookUrl}
         class="footer-link"
         aria-label="Visit our Facebook group"
         target="_blank"
@@ -28,7 +33,7 @@
         <span class="footer-link-text">Facebook</span>
       </a>
       <a
-        href="https://discord.gg/U9BYSrxH"
+        href={discordUrl}
         class="footer-link"
         aria-label="Join our Discord"
         target="_blank"

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -64,6 +64,10 @@ const djs = defineCollection({
 const pages = defineCollection({
   type: "data",
   schema: z.object({
+    // Site settings
+    discordUrl: z.string().url().optional(),
+    instagramUrl: z.string().url().optional(),
+    facebookUrl: z.string().url().optional(),
     // Home page
     heroImages: z.array(z.object({ image: z.string(), alt: z.string().optional() })).optional(),
     // Community page

--- a/src/content/pages/site-settings.yaml
+++ b/src/content/pages/site-settings.yaml
@@ -1,0 +1,3 @@
+discordUrl: 'https://discord.gg/U9BYSrxH'
+instagramUrl: 'https://www.instagram.com/whiterabbit.wcs/'
+facebookUrl: 'https://www.facebook.com/groups/183446960374256'


### PR DESCRIPTION
## Summary

- Adds a new **Site Settings** singleton to Keystatic so Discord, Instagram, and Facebook URLs can be updated via the CMS without a deploy
- Seeds `src/content/pages/site-settings.yaml` with current hardcoded values
- Footer falls back to hardcoded URLs if CMS entry is missing

Related to #7