### PR TITLE
fix: add missing install step and move ical.js to dependencies for CI

### DIFF
--- a/.github/workflows/daily-rebuild.yml
+++ b/.github/workflows/daily-rebuild.yml
@@ -17,10 +17,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
           node-version: '24'
+
+      - name: Install dependencies
+        run: pnpm install --prod
 
       - name: Fetch calendar data
         run: node scripts/fetch-calendar.js

--- a/package.json
+++ b/package.json
@@ -19,12 +19,12 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "astro": "^5.16.6",
+    "ical.js": "^2.2.1",
     "lucide-astro": "^0.556.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"
   },
   "devDependencies": {
-    "ical.js": "^2.2.1",
     "oxfmt": "^0.20.0",
     "oxlint": "^1.35.0",
     "oxlint-tsgolint": "^0.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       astro:
         specifier: ^5.16.6
         version: 5.16.6(@types/node@25.0.3)(idb-keyval@6.2.2)(rollup@4.54.0)(typescript@5.9.3)
+      ical.js:
+        specifier: ^2.2.1
+        version: 2.2.1
       lucide-astro:
         specifier: ^0.556.0
         version: 0.556.0(astro@5.16.6(@types/node@25.0.3)(idb-keyval@6.2.2)(rollup@4.54.0)(typescript@5.9.3))
@@ -42,9 +45,6 @@ importers:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
     devDependencies:
-      ical.js:
-        specifier: ^2.2.1
-        version: 2.2.1
       oxfmt:
         specifier: ^0.20.0
         version: 0.20.0


### PR DESCRIPTION
## Summary

- Adds `npm install` step to the daily-rebuild workflow — `ical.js` was missing in CI, breaking the sync
- Moves `ical.js` from `devDependencies` to `dependencies` so it's available when CI installs