### PR TITLE
feat: playlists collection with Spotify embeds + Spotify field on DJs

### DIFF
--- a/keystatic.config.ts
+++ b/keystatic.config.ts
@@ -132,6 +132,19 @@ export default config({
       },
     }),
 
+    playlists: collection({
+      label: "Playlists",
+      slugField: "title",
+      path: "src/content/playlists/*",
+      format: { data: "yaml" },
+      schema: {
+        title: fields.slug({ name: { label: "Title" } }),
+        description: fields.text({ label: "Description", multiline: true, validation: { isRequired: false } }),
+        spotifyUrl: fields.url({ label: "Spotify URL" }),
+        mood: fields.text({ label: "Mood / vibe", description: 'e.g. "Social / Late Night"', validation: { isRequired: false } }),
+      },
+    }),
+
     djs: collection({
       label: "DJs",
       slugField: "name",
@@ -152,6 +165,7 @@ export default config({
           directory: "public/images/djs",
           publicPath: "/images/djs/",
         }),
+        spotify: fields.url({ label: "Spotify", validation: { isRequired: false } }),
         mixcloud: fields.url({ label: "Mixcloud", validation: { isRequired: false } }),
         soundcloud: fields.url({ label: "SoundCloud", validation: { isRequired: false } }),
         instagram: fields.text({ label: "Instagram handle", validation: { isRequired: false } }),

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -54,6 +54,7 @@ const djs = defineCollection({
     style: z.array(z.string()).default([]),
     resident: z.boolean().default(false),
     photo: z.string().optional(),
+    spotify: z.string().url().optional(),
     mixcloud: z.string().url().optional(),
     soundcloud: z.string().url().optional(),
     instagram: z.string().optional(),
@@ -85,4 +86,14 @@ const pages = defineCollection({
   }),
 });
 
-export const collections = { posts, instructors, venues, resources, djs, pages };
+const playlists = defineCollection({
+  type: "data",
+  schema: z.object({
+    title: z.string(),
+    description: z.string().optional(),
+    spotifyUrl: z.string().url(),
+    mood: z.string().optional(),
+  }),
+});
+
+export const collections = { posts, instructors, venues, resources, djs, pages, playlists };

--- a/src/content/djs/dj-damn-yall.yaml
+++ b/src/content/djs/dj-damn-yall.yaml
@@ -9,6 +9,6 @@ bio: >-
 style: []
 resident: true
 photo: /images/djs/dj-damn-yall/photo.jpg
-soundcloud: https://open.spotify.com/playlist/0KVugxb9rPCZUhqQF8OW8k?si=7823d9333578411d
+spotify: 'https://open.spotify.com/playlist/0KVugxb9rPCZUhqQF8OW8k?si=7823d9333578411d'
 instagram: >-
   https://www.instagram.com/jordan_daniel1?utm_source=ig_web_button_share_sheet&igsh=ZDNlZDc0MzIxNw==

--- a/src/pages/music.astro
+++ b/src/pages/music.astro
@@ -12,8 +12,9 @@ const DUMMY_DJS = [
   { handle: "DJ Static", realName: "Sam T.", bio: "The anchor of early evening sets. Static builds the room up slowly — smooth vocals, laid-back grooves, and just enough tension to pull dancers onto the floor.", style: ["Soul", "Smooth RnB", "Chill Hop"], resident: false },
 ];
 
-const [djEntries, pageEntry] = await Promise.all([
+const [djEntries, playlistEntries, pageEntry] = await Promise.all([
   getCollection("djs"),
+  getCollection("playlists"),
   getEntry("pages", "music"),
 ]);
 
@@ -27,29 +28,11 @@ const copy = {
   playlistsIntro: pageEntry?.data.playlistsIntro ?? "Curated sets for home listening, practice, and late-night winding down. Full streaming links coming soon.",
 };
 
-const playlists = [
-  {
-    title: "Rabbit Hole Vol. 1",
-    description: "The essential White Rabbit sound. 90 minutes of floor-filling WCS cuts.",
-    tracks: 22,
-    bpm: "115–128",
-    mood: "Social / Late Night",
-  },
-  {
-    title: "Down the Rabbit Hole",
-    description: "Darker, slower, deeper. For when the night gets interesting.",
-    tracks: 18,
-    bpm: "100–118",
-    mood: "Intimate / Moody",
-  },
-  {
-    title: "Morning Dew",
-    description: "The after-hours wind-down. Smooth grooves for tired legs and happy hearts.",
-    tracks: 14,
-    bpm: "95–112",
-    mood: "Chill / Cool-Down",
-  },
-];
+const playlists = playlistEntries.map((e) => e.data);
+
+function toSpotifyEmbed(url: string): string {
+  return url.replace("open.spotify.com/", "open.spotify.com/embed/").split("?")[0];
+}
 ---
 
 <Layout
@@ -108,6 +91,11 @@ const playlists = [
                     <span class="tag">{s}</span>
                   ))}
                 </div>
+                {dj.spotify && (
+                  <a href={dj.spotify} class="dj-spotify" target="_blank" rel="noopener noreferrer">
+                    Spotify
+                  </a>
+                )}
               </div>
             ))
           }
@@ -119,24 +107,29 @@ const playlists = [
         <p class="section-intro">
           {copy.playlistsIntro}
         </p>
-        <div class="playlist-list">
-          {
-            playlists.map((playlist) => (
-              <div class="card playlist-card">
+        {playlists.length === 0 ? (
+          <p class="section-intro">Playlists coming soon.</p>
+        ) : (
+          <div class="playlist-list">
+            {playlists.map((playlist) => (
+              <div class="playlist-card">
                 <div class="playlist-header">
                   <span class="playlist-title">{playlist.title}</span>
-                  <span class="playlist-mood">{playlist.mood}</span>
+                  {playlist.mood && <span class="playlist-mood">{playlist.mood}</span>}
                 </div>
-                <p class="playlist-desc">{playlist.description}</p>
-                <div class="playlist-meta">
-                  <span>{playlist.tracks} tracks</span>
-                  <span>{playlist.bpm} BPM</span>
-                  <span class="coming-soon">Streaming link coming soon</span>
-                </div>
+                {playlist.description && <p class="playlist-desc">{playlist.description}</p>}
+                <iframe
+                  src={toSpotifyEmbed(playlist.spotifyUrl)}
+                  width="100%"
+                  height="352"
+                  frameborder="0"
+                  allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
+                  loading="lazy"
+                ></iframe>
               </div>
-            ))
-          }
-        </div>
+            ))}
+          </div>
+        )}
       </section>
     </div>
   </main>
@@ -339,18 +332,28 @@ const playlists = [
     margin: 0 0 10px;
   }
 
-  .playlist-meta {
-    display: flex;
-    gap: 16px;
-    font-size: 0.8rem;
-    color: var(--text-muted);
-    font-family: var(--font-primary);
-    flex-wrap: wrap;
+  .playlist-card iframe {
+    border: 1px solid var(--border-color);
+    border-radius: 0;
+    display: block;
   }
 
-  .coming-soon {
-    color: var(--accent-secondary);
-    font-style: italic;
+  .dj-spotify {
+    display: inline-block;
+    margin-top: 10px;
+    font-size: 0.8rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--accent-primary);
+    text-decoration: none;
+    border: 1px solid var(--accent-primary);
+    padding: 4px 10px;
+    transition: background 0.2s, color 0.2s;
+  }
+
+  .dj-spotify:hover {
+    background: var(--accent-primary);
+    color: var(--bg-primary);
   }
 
   @media (max-width: 768px) {


### PR DESCRIPTION
## Summary

- New **Playlists** collection in Keystatic — title, description, Spotify URL, mood/vibe
- Playlists render as Spotify iFrame embeds on the music page
- **Spotify** URL field added to DJ collection, shown as a link on DJ cards
- Falls back gracefully to "Playlists coming soon" if no entries exist
- Moved DJ DamnYall's Spotify URL from the SoundCloud field to the correct Spotify field

Closes #25
Closes #21