### PR TITLE
feat: defer Turnstile widget until form interaction

### DIFF
--- a/src/components/DiscordForm.astro
+++ b/src/components/DiscordForm.astro
@@ -35,7 +35,7 @@ const PHOENIX_CITIES = [
       </select>
     </div>
     {siteKey && (
-      <div class="cf-turnstile" data-sitekey={siteKey} data-theme="dark"></div>
+      <div class="cf-turnstile" data-sitekey={siteKey} data-theme="dark" style="display:none"></div>
     )}
     <button type="submit" class="btn submit-btn">Request invite</button>
     <p class="form-status" id="dc-status" aria-live="polite"></p>
@@ -47,6 +47,16 @@ const PHOENIX_CITIES = [
 <script>
   const form = document.getElementById("discord-form") as HTMLFormElement;
   const status = document.getElementById("dc-status") as HTMLParagraphElement;
+
+  const turnstileContainer = form?.querySelector<HTMLElement>(".cf-turnstile");
+  if (turnstileContainer) {
+    form.querySelectorAll("input, select").forEach((el) => {
+      el.addEventListener("focus", () => { turnstileContainer.style.display = ""; }, { once: true });
+    });
+    form.querySelector<HTMLButtonElement>(".submit-btn")?.addEventListener("click", () => {
+      turnstileContainer.style.display = "";
+    }, { once: true });
+  }
 
   form?.addEventListener("submit", async (e) => {
     e.preventDefault();

--- a/src/components/FeedbackForm.astro
+++ b/src/components/FeedbackForm.astro
@@ -22,7 +22,7 @@ const siteKey = "0x4AAAAAAC-SjNYO1rM3LezP";
           <textarea id="fb-message" name="message" rows="4" required></textarea>
         </div>
         {siteKey && (
-          <div class="cf-turnstile" data-sitekey={siteKey} data-theme="dark"></div>
+          <div class="cf-turnstile" data-sitekey={siteKey} data-theme="dark" style="display:none"></div>
         )}
         <button type="submit" class="btn submit-btn">Send message</button>
         <p class="form-status" id="fb-status" aria-live="polite"></p>
@@ -36,6 +36,16 @@ const siteKey = "0x4AAAAAAC-SjNYO1rM3LezP";
 <script>
   const form = document.getElementById("feedback-form") as HTMLFormElement;
   const status = document.getElementById("fb-status") as HTMLParagraphElement;
+
+  const turnstileContainer = form?.querySelector<HTMLElement>(".cf-turnstile");
+  if (turnstileContainer) {
+    form.querySelectorAll("input, textarea").forEach((el) => {
+      el.addEventListener("focus", () => { turnstileContainer.style.display = ""; }, { once: true });
+    });
+    form.querySelector<HTMLButtonElement>(".submit-btn")?.addEventListener("click", () => {
+      turnstileContainer.style.display = "";
+    }, { once: true });
+  }
 
   form?.addEventListener("submit", async (e) => {
     e.preventDefault();


### PR DESCRIPTION
## Summary

- Hide the Cloudflare Turnstile widget on initial page load
- Reveal it when the user focuses any form field (name, email, message, city) or clicks the submit button
- Applies to both `FeedbackForm` and `DiscordForm`

The widget still auto-renders in the background while hidden, so the challenge token is ready well before the user submits.