### PR TITLE
feat: add Instagram and web links to DJ and instructor profile cards

### DIFF
--- a/src/pages/community.astro
+++ b/src/pages/community.astro
@@ -83,6 +83,20 @@ const copy = {
                     <span class="tag">{s}</span>
                   ))}
                 </div>
+                {(instructor.instagram || instructor.website) && (
+                  <div class="instructor-links">
+                    {instructor.instagram && (
+                      <a href={`https://instagram.com/${instructor.instagram.replace(/^@/, "")}`} class="instructor-link" target="_blank" rel="noopener noreferrer">
+                        Instagram
+                      </a>
+                    )}
+                    {instructor.website && (
+                      <a href={instructor.website} class="instructor-link" target="_blank" rel="noopener noreferrer">
+                        Website
+                      </a>
+                    )}
+                  </div>
+                )}
               </div>
             ))
           }
@@ -240,6 +254,29 @@ const copy = {
     border: 1px solid var(--border-color);
     color: var(--text-secondary);
     border-radius: 2px;
+  }
+
+  .instructor-links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-top: 12px;
+  }
+
+  .instructor-link {
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--accent-primary);
+    text-decoration: none;
+    border: 1px solid var(--accent-primary);
+    padding: 4px 10px;
+    transition: background 0.2s, color 0.2s;
+  }
+
+  .instructor-link:hover {
+    background: var(--accent-primary);
+    color: var(--bg-primary);
   }
 
   .venue-name {

--- a/src/pages/music.astro
+++ b/src/pages/music.astro
@@ -96,10 +96,29 @@ function toSpotifyEmbed(url: string): string {
                     <span class="tag">{s}</span>
                   ))}
                 </div>
-                {dj.spotify && (
-                  <a href={dj.spotify} class="dj-spotify" target="_blank" rel="noopener noreferrer">
-                    Spotify
-                  </a>
+                {(dj.instagram || dj.spotify || dj.mixcloud || dj.soundcloud) && (
+                  <div class="dj-links">
+                    {dj.instagram && (
+                      <a href={`https://instagram.com/${dj.instagram.replace(/^@/, "")}`} class="dj-link" target="_blank" rel="noopener noreferrer">
+                        Instagram
+                      </a>
+                    )}
+                    {dj.spotify && (
+                      <a href={dj.spotify} class="dj-link" target="_blank" rel="noopener noreferrer">
+                        Spotify
+                      </a>
+                    )}
+                    {dj.mixcloud && (
+                      <a href={dj.mixcloud} class="dj-link" target="_blank" rel="noopener noreferrer">
+                        Mixcloud
+                      </a>
+                    )}
+                    {dj.soundcloud && (
+                      <a href={dj.soundcloud} class="dj-link" target="_blank" rel="noopener noreferrer">
+                        SoundCloud
+                      </a>
+                    )}
+                  </div>
                 )}
               </div>
             ))
@@ -357,10 +376,15 @@ function toSpotifyEmbed(url: string): string {
     display: block;
   }
 
-  .dj-spotify {
-    display: inline-block;
-    margin-top: 10px;
-    font-size: 0.8rem;
+  .dj-links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-top: 12px;
+  }
+
+  .dj-link {
+    font-size: 0.75rem;
     letter-spacing: 0.08em;
     text-transform: uppercase;
     color: var(--accent-primary);
@@ -370,7 +394,7 @@ function toSpotifyEmbed(url: string): string {
     transition: background 0.2s, color 0.2s;
   }
 
-  .dj-spotify:hover {
+  .dj-link:hover {
     background: var(--accent-primary);
     color: var(--bg-primary);
   }


### PR DESCRIPTION
## Summary

- **DJ cards** (music page): adds Instagram, Spotify, Mixcloud, and SoundCloud links as small bordered buttons below the style tags
- **Instructor cards** (community page): adds Instagram and Website links below the specialty tags
- Links only render when the field is populated on the content entry — no empty UI for missing data
- Styled consistently with the existing site aesthetic (small uppercase bordered pill that fills on hover)