### PR TITLE
Add Music and Shop to navigation

### DIFF
--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -6,6 +6,8 @@ const navLinks = [
   { href: "/", label: "Home" },
   { href: "/events", label: "Events" },
   { href: "/community", label: "Community" },
+  { href: "/music", label: "Music" },
+  { href: "/shop", label: "Shop" },
   { href: "/gallery", label: "Gallery" },
   { href: "/about", label: "About" },
 ];
@@ -227,7 +229,7 @@ const navLinks = [
     }
 
     .nav-links.active {
-      max-height: 400px;
+      max-height: 560px;
     }
 
     .nav-link {


### PR DESCRIPTION
## Summary

- Adds Music and Shop links to the main nav between Community and Gallery
- Both pages already exist (`/music`, `/shop`)
- Bumped mobile menu `max-height` to accommodate the two new items

## Test plan

- [ ] Music and Shop appear in desktop nav
- [ ] Both links are active-highlighted on their respective pages
- [ ] Mobile hamburger menu shows all links and scrolls correctly