### PR TITLE
Add Printful product refresh to daily sync action

### DIFF
--- a/.github/workflows/daily-rebuild.yml
+++ b/.github/workflows/daily-rebuild.yml
@@ -11,7 +11,7 @@ permissions:
   contents: write
 
 jobs:
-  sync:
+  sync-calendar:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/daily-rebuild.yml
+++ b/.github/workflows/daily-rebuild.yml
@@ -1,4 +1,4 @@
-name: Daily Calendar Sync
+name: Daily Data Sync
 
 on:
   schedule:
@@ -11,7 +11,7 @@ permissions:
   contents: write
 
 jobs:
-  sync-calendar:
+  sync:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -36,14 +36,20 @@ jobs:
           PUBLIC_GOOGLE_CALENDAR_ID: ${{ secrets.PUBLIC_GOOGLE_CALENDAR_ID }}
           GOOGLE_CALENDAR_API_KEY: ${{ secrets.GOOGLE_CALENDAR_API_KEY }}
 
+      - name: Fetch Printful products
+        run: node scripts/fetch-products.js
+        env:
+          PRINTFUL_API_KEY: ${{ secrets.PRINTFUL_API_KEY }}
+          PRINTFUL_STORE_ID: ${{ secrets.PRINTFUL_STORE_ID }}
+
       - name: Commit and push if changed
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add src/data/events.json
+          git add src/data/events.json src/data/products.json
           if git diff --staged --quiet; then
-            echo "No changes to calendar data"
+            echo "No changes to data"
           else
-            git commit -m "chore: sync calendar data"
+            git commit -m "chore: sync calendar and product data"
             git push
           fi

--- a/.github/workflows/refresh-products.yml
+++ b/.github/workflows/refresh-products.yml
@@ -1,17 +1,13 @@
-name: Daily Calendar Sync
+name: Refresh Printful Products
 
 on:
-  schedule:
-    # Run daily at 6 AM UTC (11 PM Arizona time)
-    - cron: '0 6 * * *'
   workflow_dispatch:
-    # Allow manual trigger from GitHub Actions UI
 
 permissions:
   contents: write
 
 jobs:
-  sync:
+  refresh:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -30,20 +26,20 @@ jobs:
       - name: Install dependencies
         run: pnpm install --prod
 
-      - name: Fetch calendar data
-        run: node scripts/fetch-calendar.js
+      - name: Fetch Printful products
+        run: node scripts/fetch-products.js
         env:
-          PUBLIC_GOOGLE_CALENDAR_ID: ${{ secrets.PUBLIC_GOOGLE_CALENDAR_ID }}
-          GOOGLE_CALENDAR_API_KEY: ${{ secrets.GOOGLE_CALENDAR_API_KEY }}
+          PRINTFUL_API_KEY: ${{ secrets.PRINTFUL_API_KEY }}
+          PRINTFUL_STORE_ID: ${{ secrets.PRINTFUL_STORE_ID }}
 
       - name: Commit and push if changed
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add src/data/events.json
+          git add src/data/products.json
           if git diff --staged --quiet; then
-            echo "No changes to calendar data"
+            echo "No changes to product data"
           else
-            git commit -m "chore: sync calendar data"
+            git commit -m "chore: refresh product data"
             git push
           fi

--- a/src/data/products.json
+++ b/src/data/products.json
@@ -1,90 +1,152 @@
 [
   {
+    "id": 429717565,
+    "name": "Short-Sleeve Unisex T-Shirt",
+    "description": "",
+    "thumbnailUrl": "https://files.cdn.printful.com/files/cd5/cd51a444c28804d1880a57a949e349ff_preview.png",
+    "variants": [
+      {
+        "id": 5281194248,
+        "name": "Short-Sleeve Unisex T-Shirt / S",
+        "size": "S",
+        "color": "Black",
+        "price": "32.00",
+        "inStock": true,
+        "previewUrl": "https://files.cdn.printful.com/files/cd5/cd51a444c28804d1880a57a949e349ff_preview.png"
+      },
+      {
+        "id": 5281194249,
+        "name": "Short-Sleeve Unisex T-Shirt / M",
+        "size": "M",
+        "color": "Black",
+        "price": "32.00",
+        "inStock": true,
+        "previewUrl": "https://files.cdn.printful.com/files/cd5/cd51a444c28804d1880a57a949e349ff_preview.png"
+      },
+      {
+        "id": 5281194250,
+        "name": "Short-Sleeve Unisex T-Shirt / L",
+        "size": "L",
+        "color": "Black",
+        "price": "32.00",
+        "inStock": true,
+        "previewUrl": "https://files.cdn.printful.com/files/cd5/cd51a444c28804d1880a57a949e349ff_preview.png"
+      },
+      {
+        "id": 5281194251,
+        "name": "Short-Sleeve Unisex T-Shirt / XL",
+        "size": "XL",
+        "color": "Black",
+        "price": "32.00",
+        "inStock": true,
+        "previewUrl": "https://files.cdn.printful.com/files/cd5/cd51a444c28804d1880a57a949e349ff_preview.png"
+      },
+      {
+        "id": 5281194252,
+        "name": "Short-Sleeve Unisex T-Shirt / 2XL",
+        "size": "2XL",
+        "color": "Black",
+        "price": "32.00",
+        "inStock": true,
+        "previewUrl": "https://files.cdn.printful.com/files/cd5/cd51a444c28804d1880a57a949e349ff_preview.png"
+      },
+      {
+        "id": 5281194253,
+        "name": "Short-Sleeve Unisex T-Shirt / 3XL",
+        "size": "3XL",
+        "color": "Black",
+        "price": "32.00",
+        "inStock": true,
+        "previewUrl": "https://files.cdn.printful.com/files/cd5/cd51a444c28804d1880a57a949e349ff_preview.png"
+      }
+    ]
+  },
+  {
     "id": 429713304,
-    "name": "Unisex t-shirt",
+    "name": "\"White Rabbit West Coast\" t-shirt",
     "description": "",
     "thumbnailUrl": "https://files.cdn.printful.com/files/346/3461d666f3eb06fa1a19e86661111a2c_preview.png",
     "variants": [
       {
         "id": 5281161347,
-        "name": "Unisex t-shirt / XS",
+        "name": "\"White Rabbit West Coast\" t-shirt / XS",
         "size": "XS",
         "color": "Black",
-        "price": "16.91",
+        "price": "30.00",
         "inStock": true,
-        "previewUrl": "https://files.cdn.printful.com/files/077/0775b20e7bdfc4e5b8d4043957a72971_preview.png"
+        "previewUrl": "https://files.cdn.printful.com/files/71c/71ce6431d205cc97322378128470cab3_preview.png"
       },
       {
         "id": 5281161348,
-        "name": "Unisex t-shirt / S",
+        "name": "\"White Rabbit West Coast\" t-shirt / S",
         "size": "S",
         "color": "Black",
-        "price": "16.91",
+        "price": "30.00",
         "inStock": true,
-        "previewUrl": "https://files.cdn.printful.com/files/077/0775b20e7bdfc4e5b8d4043957a72971_preview.png"
+        "previewUrl": "https://files.cdn.printful.com/files/71c/71ce6431d205cc97322378128470cab3_preview.png"
       },
       {
         "id": 5281161349,
-        "name": "Unisex t-shirt / M",
+        "name": "\"White Rabbit West Coast\" t-shirt / M",
         "size": "M",
         "color": "Black",
-        "price": "16.91",
+        "price": "30.00",
         "inStock": true,
-        "previewUrl": "https://files.cdn.printful.com/files/077/0775b20e7bdfc4e5b8d4043957a72971_preview.png"
+        "previewUrl": "https://files.cdn.printful.com/files/71c/71ce6431d205cc97322378128470cab3_preview.png"
       },
       {
         "id": 5281161350,
-        "name": "Unisex t-shirt / L",
+        "name": "\"White Rabbit West Coast\" t-shirt / L",
         "size": "L",
         "color": "Black",
-        "price": "16.91",
+        "price": "30.00",
         "inStock": true,
-        "previewUrl": "https://files.cdn.printful.com/files/077/0775b20e7bdfc4e5b8d4043957a72971_preview.png"
+        "previewUrl": "https://files.cdn.printful.com/files/71c/71ce6431d205cc97322378128470cab3_preview.png"
       },
       {
         "id": 5281161351,
-        "name": "Unisex t-shirt / XL",
+        "name": "\"White Rabbit West Coast\" t-shirt / XL",
         "size": "XL",
         "color": "Black",
-        "price": "16.91",
+        "price": "30.00",
         "inStock": true,
-        "previewUrl": "https://files.cdn.printful.com/files/077/0775b20e7bdfc4e5b8d4043957a72971_preview.png"
+        "previewUrl": "https://files.cdn.printful.com/files/71c/71ce6431d205cc97322378128470cab3_preview.png"
       },
       {
         "id": 5281161353,
-        "name": "Unisex t-shirt / 2XL",
+        "name": "\"White Rabbit West Coast\" t-shirt / 2XL",
         "size": "2XL",
         "color": "Black",
-        "price": "19.51",
+        "price": "30.00",
         "inStock": true,
-        "previewUrl": "https://files.cdn.printful.com/files/077/0775b20e7bdfc4e5b8d4043957a72971_preview.png"
+        "previewUrl": "https://files.cdn.printful.com/files/71c/71ce6431d205cc97322378128470cab3_preview.png"
       },
       {
         "id": 5281161354,
-        "name": "Unisex t-shirt / 3XL",
+        "name": "\"White Rabbit West Coast\" t-shirt / 3XL",
         "size": "3XL",
         "color": "Black",
-        "price": "22.11",
+        "price": "35.00",
         "inStock": true,
-        "previewUrl": "https://files.cdn.printful.com/files/077/0775b20e7bdfc4e5b8d4043957a72971_preview.png"
+        "previewUrl": "https://files.cdn.printful.com/files/71c/71ce6431d205cc97322378128470cab3_preview.png"
       },
       {
         "id": 5281161355,
-        "name": "Unisex t-shirt / 4XL",
+        "name": "\"White Rabbit West Coast\" t-shirt / 4XL",
         "size": "4XL",
         "color": "Black",
-        "price": "24.71",
+        "price": "35.00",
         "inStock": true,
-        "previewUrl": "https://files.cdn.printful.com/files/077/0775b20e7bdfc4e5b8d4043957a72971_preview.png"
+        "previewUrl": "https://files.cdn.printful.com/files/71c/71ce6431d205cc97322378128470cab3_preview.png"
       },
       {
         "id": 5281161357,
-        "name": "Unisex t-shirt / 5XL",
+        "name": "\"White Rabbit West Coast\" t-shirt / 5XL",
         "size": "5XL",
         "color": "Black",
-        "price": "27.31",
+        "price": "35.00",
         "inStock": true,
-        "previewUrl": "https://files.cdn.printful.com/files/077/0775b20e7bdfc4e5b8d4043957a72971_preview.png"
+        "previewUrl": "https://files.cdn.printful.com/files/71c/71ce6431d205cc97322378128470cab3_preview.png"
       }
     ]
   },
@@ -99,7 +161,7 @@
         "name": "Unisex t-shirt / XS",
         "size": "XS",
         "color": "Black",
-        "price": "16.91",
+        "price": "30.00",
         "inStock": true,
         "previewUrl": "https://files.cdn.printful.com/files/d4b/d4b23aa3133e29425bc49000c7b2c9e3_preview.png"
       },
@@ -108,7 +170,7 @@
         "name": "Unisex t-shirt / S",
         "size": "S",
         "color": "Black",
-        "price": "16.91",
+        "price": "30.00",
         "inStock": true,
         "previewUrl": "https://files.cdn.printful.com/files/d4b/d4b23aa3133e29425bc49000c7b2c9e3_preview.png"
       },
@@ -117,7 +179,7 @@
         "name": "Unisex t-shirt / M",
         "size": "M",
         "color": "Black",
-        "price": "16.91",
+        "price": "30.00",
         "inStock": true,
         "previewUrl": "https://files.cdn.printful.com/files/d4b/d4b23aa3133e29425bc49000c7b2c9e3_preview.png"
       },
@@ -126,7 +188,7 @@
         "name": "Unisex t-shirt / L",
         "size": "L",
         "color": "Black",
-        "price": "16.91",
+        "price": "30.00",
         "inStock": true,
         "previewUrl": "https://files.cdn.printful.com/files/d4b/d4b23aa3133e29425bc49000c7b2c9e3_preview.png"
       },
@@ -135,7 +197,7 @@
         "name": "Unisex t-shirt / XL",
         "size": "XL",
         "color": "Black",
-        "price": "16.91",
+        "price": "30.00",
         "inStock": true,
         "previewUrl": "https://files.cdn.printful.com/files/d4b/d4b23aa3133e29425bc49000c7b2c9e3_preview.png"
       },
@@ -144,7 +206,7 @@
         "name": "Unisex t-shirt / 2XL",
         "size": "2XL",
         "color": "Black",
-        "price": "19.51",
+        "price": "30.00",
         "inStock": true,
         "previewUrl": "https://files.cdn.printful.com/files/d4b/d4b23aa3133e29425bc49000c7b2c9e3_preview.png"
       },
@@ -153,7 +215,7 @@
         "name": "Unisex t-shirt / 3XL",
         "size": "3XL",
         "color": "Black",
-        "price": "22.11",
+        "price": "35.00",
         "inStock": true,
         "previewUrl": "https://files.cdn.printful.com/files/d4b/d4b23aa3133e29425bc49000c7b2c9e3_preview.png"
       },
@@ -162,7 +224,7 @@
         "name": "Unisex t-shirt / 4XL",
         "size": "4XL",
         "color": "Black",
-        "price": "24.71",
+        "price": "35.00",
         "inStock": true,
         "previewUrl": "https://files.cdn.printful.com/files/d4b/d4b23aa3133e29425bc49000c7b2c9e3_preview.png"
       },
@@ -171,7 +233,7 @@
         "name": "Unisex t-shirt / 5XL",
         "size": "5XL",
         "color": "Black",
-        "price": "27.31",
+        "price": "35.00",
         "inStock": true,
         "previewUrl": "https://files.cdn.printful.com/files/d4b/d4b23aa3133e29425bc49000c7b2c9e3_preview.png"
       }
@@ -188,18 +250,18 @@
         "name": "Trucker Cap / Black/ White",
         "size": "One size",
         "color": "Black/ White",
-        "price": "19.31",
+        "price": "25.00",
         "inStock": true,
-        "previewUrl": "https://files.cdn.printful.com/files/6f2/6f2b0535abaa4e1b8daa3f9a162cc2c9_preview.png"
+        "previewUrl": "https://files.cdn.printful.com/files/533/5331e7529c67ff660afb37d8c598bfe4_preview.png"
       },
       {
         "id": 5281161309,
         "name": "Trucker Cap / White",
         "size": "One size",
         "color": "White",
-        "price": "19.31",
+        "price": "25.00",
         "inStock": true,
-        "previewUrl": "https://files.cdn.printful.com/files/685/685d8b29b6c273c90294f7d2476cda0f_preview.png"
+        "previewUrl": "https://files.cdn.printful.com/files/05b/05b488585d2b583329572f1552df11ca_preview.png"
       }
     ]
   }


### PR DESCRIPTION
## Summary
- Daily sync workflow restored to calendar-only (products don't change daily)
- New `refresh-products.yml` workflow — manual trigger only, run it whenever you update products in Printful
- Commits updated `products.json` to trigger a Cloudflare redeploy
- `PRINTFUL_API_KEY` and `PRINTFUL_STORE_ID` secrets already added to the repo

## Also includes
- Refreshed `products.json` with latest data from Printful (4 products, including new Short-Sleeve Unisex T-Shirt)