### PR TITLE
Fix RRule import for Cloudflare ESM build

### DIFF
--- a/src/lib/calendar.ts
+++ b/src/lib/calendar.ts
@@ -1,7 +1,6 @@
 import { readFileSync, existsSync } from "fs";
 import { join } from "path";
-import pkg from "rrule";
-const { RRule } = pkg;
+import { RRule } from "rrule";
 
 export interface CalendarEvent {
   id: string;


### PR DESCRIPTION
The default import pattern (import pkg from 'rrule') fails in Cloudflare's Rollup/ESM build. Switched to named import which works in both Node and ESM environments.