### PR TITLE
Generate resized WebP variants from WebP source images

### DIFF
--- a/scripts/convert-hero-images.js
+++ b/scripts/convert-hero-images.js
@@ -1,4 +1,4 @@
-// Converts hero images (PNG/JPG) to WebP at 3 sizes if not already done.
+// Converts hero images (PNG/JPG/WebP) to WebP at 3 sizes if not already done.
 // Removes orphaned WebP files whose source image no longer exists.
 // Requires ffmpeg on PATH; skips gracefully if unavailable.
 
@@ -32,7 +32,7 @@ let removed = 0;
 
 for (const entry of readdirSync(heroDir)) {
   const dir = join(heroDir, entry);
-  const source = ['image.png', 'image.jpg', 'image.jpeg']
+  const source = ['image.png', 'image.jpg', 'image.jpeg', 'image.webp']
     .map(f => join(dir, f))
     .find(f => existsSync(f));
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,7 +10,7 @@ import { getEntry } from "astro:content";
 const schema = generateOrganizationSchema();
 const homeData = await getEntry("pages", "home");
 const heroImages = (homeData?.data.heroImages?.filter((i) => i.image) ?? []).map((item) => {
-  const base = item.image.replace(/\.(png|jpe?g)$/i, "");
+  const base = item.image.replace(/\.(png|jpe?g|webp)$/i, "");
   const hasWebp = existsSync(join(process.cwd(), "public", `${base}.webp`));
   return { ...item, base, hasWebp };
 });


### PR DESCRIPTION
If someone uploads a WebP directly via Keystatic, the conversion script now generates the 400/800/1600px variants from it just like it would for PNG/JPG.