### PR TITLE
fix: use Temporal API for calendar today marker

### DIFF
--- a/src/components/MonthCalendar.astro
+++ b/src/components/MonthCalendar.astro
@@ -34,8 +34,13 @@ const { events } = Astro.props;
   <div class="cal-day-events" id="cal-day-events" aria-live="polite"></div>
 </div>
 
-<script define:vars={{ calEvents: events }}>
-  const calToday = new Date().toLocaleDateString('en-CA', { timeZone: 'America/Phoenix' });
+<script type="application/json" id="cal-event-data" set:html={JSON.stringify(events).replace(/<\//g, '<\\/')}></script>
+
+<script>
+  import { Temporal } from '@js-temporal/polyfill';
+
+  const calEvents = JSON.parse(document.getElementById('cal-event-data')!.textContent!);
+  const calToday = Temporal.Now.plainDateISO('America/Phoenix').toString();
   const MONTHS = [
     'January','February','March','April','May','June',
     'July','August','September','October','November','December'

--- a/src/pages/events.astro
+++ b/src/pages/events.astro
@@ -27,8 +27,14 @@ const pastEvents = events
   .filter(e => e.date < today)
   .sort((a, b) => b.date.localeCompare(a.date) || b.startTime.localeCompare(a.startTime));
 
-// Generate structured data for upcoming events
 const schema = generateEventListSchema(upcomingEvents);
+
+const PHOENIX_METRO = ['Phoenix', 'Scottsdale', 'Tempe', 'Mesa', 'Glendale', 'Chandler', 'Gilbert', 'Peoria', 'Surprise', 'Avondale'];
+function eventCity(address: string) {
+  const match = address.match(/,\s*([^,]+),\s*AZ/);
+  const raw = match ? match[1].trim() : 'Phoenix';
+  return PHOENIX_METRO.some(c => raw.toLowerCase().includes(c.toLowerCase())) ? 'Phoenix' : raw;
+}
 
 ---
 
@@ -134,21 +140,11 @@ const schema = generateEventListSchema(upcomingEvents);
       {upcomingEvents.length > 0 && (
         <section class="events-section">
           <div class="events-list">
-            {upcomingEvents.map(event => {
-              // Extract city from address (format: "123 Street, Phoenix, AZ 85001")
-              const cityMatch = event.address.match(/,\s*([^,]+),\s*AZ/);
-              const rawCity = cityMatch ? cityMatch[1].trim() : 'Phoenix';
-
-              // Map Phoenix metro area cities to "Phoenix"
-              const phoenixMetro = ['Phoenix', 'Scottsdale', 'Tempe', 'Mesa', 'Glendale', 'Chandler', 'Gilbert', 'Peoria', 'Surprise', 'Avondale'];
-              const city = phoenixMetro.some(c => rawCity.toLowerCase().includes(c.toLowerCase())) ? 'Phoenix' : rawCity;
-
-              return (
-                <div class="event-item" data-type={event.type} data-city={city}>
-                  <EventCard event={event} />
-                </div>
-              );
-            })}
+            {upcomingEvents.map(event => (
+              <div class="event-item" data-type={event.type} data-city={eventCity(event.address)}>
+                <EventCard event={event} />
+              </div>
+            ))}
           </div>
         </section>
       )}
@@ -157,21 +153,11 @@ const schema = generateEventListSchema(upcomingEvents);
         <section class="events-section past-events">
           <h2 class="section-title">> Past Events</h2>
           <div class="events-list">
-            {pastEvents.map(event => {
-              // Extract city from address (format: "123 Street, Phoenix, AZ 85001")
-              const cityMatch = event.address.match(/,\s*([^,]+),\s*AZ/);
-              const rawCity = cityMatch ? cityMatch[1].trim() : 'Phoenix';
-
-              // Map Phoenix metro area cities to "Phoenix"
-              const phoenixMetro = ['Phoenix', 'Scottsdale', 'Tempe', 'Mesa', 'Glendale', 'Chandler', 'Gilbert', 'Peoria', 'Surprise', 'Avondale'];
-              const city = phoenixMetro.some(c => rawCity.toLowerCase().includes(c.toLowerCase())) ? 'Phoenix' : rawCity;
-
-              return (
-                <div class="event-item" data-type={event.type} data-city={city}>
-                  <EventCard event={event} />
-                </div>
-              );
-            })}
+            {pastEvents.map(event => (
+              <div class="event-item" data-type={event.type} data-city={eventCity(event.address)}>
+                <EventCard event={event} />
+              </div>
+            ))}
           </div>
         </section>
       )}


### PR DESCRIPTION
## Summary

- Replaces the build-time `new Date()` in `MonthCalendar` with `Temporal.Now.plainDateISO('America/Phoenix')` so the today highlight is always accurate regardless of when Cloudflare last deployed
- Switches from `define:vars` (inline script, no imports) to a module script + `<script type="application/json">` data island so the `@js-temporal/polyfill` import works correctly
- Reverts the client-side past/upcoming list split from the previous attempt — it caused a deferred-script layout shift and broke progressive enhancement (all events rendered in wrong order without JS)

## Test plan

- [ ] Calendar today cell shows the correct date (not the deploy date)
- [ ] Navigating months forward/backward still works
- [ ] Clicking a day still opens the event panel
- [ ] Works in Safari (polyfill covers pre-18.4 where Temporal wasn't native)