### PR TITLE
feat: gallery subdirectory album support

### DIFF
--- a/src/pages/gallery.astro
+++ b/src/pages/gallery.astro
@@ -43,7 +43,7 @@ if (accountId && apiToken) {
     for (const obj of data.result) {
       if (!IMAGE_EXTS.test(obj.key) && !VIDEO_EXTS.test(obj.key)) continue;
       const segments = obj.key.split("/");
-      const album = segments.length > 1 ? segments[0] : null;
+      const album = segments.length > 1 ? segments.slice(0, -1).join("/") : null;
       const name = segments[segments.length - 1];
       items.push({
         key: obj.key,
@@ -97,7 +97,7 @@ Astro.response.headers.set("Cache-Control", "public, max-age=3600, s-maxage=8640
         <section class="album">
           {album ? (
             <details open>
-              <summary class="album-title">{album.replace(/-/g, " ")}</summary>
+              <summary class="album-title">{album.split("/").map(s => s.replace(/-/g, " ")).join(" / ")}</summary>
               <div class="grid">
                 {albumItems.map((item) => (
                   <button class="grid-item" data-url={item.url} data-video={item.isVideo ? "true" : undefined} aria-label={item.name}>


### PR DESCRIPTION
## Summary
- Album key now uses the full parent path (`events/2025`) instead of just the first segment (`events`), so nested folders become separate albums
- Display renders path separators as ` / ` with dashes converted to spaces (e.g. `my-event/2025` → `my event / 2025`)

## Test plan
- [ ] Upload photos into a nested folder (e.g. `events/2025/`) in R2 and verify they appear as a separate album from `events/2024/`
- [ ] Verify root-level photos (no folder) still show ungrouped
- [ ] Verify album titles render cleanly