### PR TITLE
perf: cache R2 gallery listing in KV

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,25 @@ Markdown posts live in `src/content/posts/` and are managed via Astro Content Co
 | `keystatic.config.ts` | Keystatic CMS schema — collections and singletons |
 | `src/content/pages/` | Singleton CMS data (home, community, music page copy) |
 
+### Gallery
+
+`src/pages/gallery.astro` is an SSR page that lists photos and videos from the `white-rabbit-gallery` R2 bucket.
+
+**How it works:**
+
+1. On request, check the `SESSION` KV namespace for a cached listing under the key `gallery:listing`
+2. **Cache hit** → deserialize and render immediately (instant)
+3. **Cache miss** → call the Cloudflare R2 listing API, render, then write the result to KV in the background (TTL: 1 hour). The background write uses a fire-and-forget `kv.put()` so the response isn't held up
+4. Images are served directly from the R2 public URL (`pub-*.r2.dev`), not proxied through the Worker
+
+The cold-cache path (first request after TTL expires) is slow — ~10s for a large bucket — because it paginates the R2 API. Every subsequent request within the hour is instant from KV.
+
+**To force a cache refresh** (e.g. after uploading new photos): delete the `gallery:listing` key from the `SESSION` KV namespace in the Cloudflare dashboard, or wait for the 1-hour TTL to expire.
+
+Required env vars (set via `wrangler secret put`):
+- `WHITE_RABBIT_ACCOUNT_ID` — Cloudflare account ID
+- `WHITE_RABBIT_R2_API_TOKEN` — R2 API token with read access to `white-rabbit-gallery`
+
 ### CI / Automated Refresh
 
 `.github/workflows/daily-rebuild.yml` runs daily (6 AM UTC) — fetches the calendar, commits `events.json` if changed, then Cloudflare redeploys. `.github/workflows/debug-calendar.yml` is manually triggered and uploads `calendar.ics` + `events.json` as artifacts for troubleshooting.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,25 +95,6 @@ Markdown posts live in `src/content/posts/` and are managed via Astro Content Co
 | `keystatic.config.ts` | Keystatic CMS schema — collections and singletons |
 | `src/content/pages/` | Singleton CMS data (home, community, music page copy) |
 
-### Gallery
-
-`src/pages/gallery.astro` is an SSR page that lists photos and videos from the `white-rabbit-gallery` R2 bucket.
-
-**How it works:**
-
-1. On request, check the `SESSION` KV namespace for a cached listing under the key `gallery:listing`
-2. **Cache hit** → deserialize and render immediately (instant)
-3. **Cache miss** → call the Cloudflare R2 listing API, render, then write the result to KV in the background (TTL: 1 hour). The background write uses a fire-and-forget `kv.put()` so the response isn't held up
-4. Images are served directly from the R2 public URL (`pub-*.r2.dev`), not proxied through the Worker
-
-The cold-cache path (first request after TTL expires) is slow — ~10s for a large bucket — because it paginates the R2 API. Every subsequent request within the hour is instant from KV.
-
-**To force a cache refresh** (e.g. after uploading new photos): delete the `gallery:listing` key from the `SESSION` KV namespace in the Cloudflare dashboard, or wait for the 1-hour TTL to expire.
-
-Required env vars (set via `wrangler secret put`):
-- `WHITE_RABBIT_ACCOUNT_ID` — Cloudflare account ID
-- `WHITE_RABBIT_R2_API_TOKEN` — R2 API token with read access to `white-rabbit-gallery`
-
 ### CI / Automated Refresh
 
 `.github/workflows/daily-rebuild.yml` runs daily (6 AM UTC) — fetches the calendar, commits `events.json` if changed, then Cloudflare redeploys. `.github/workflows/debug-calendar.yml` is manually triggered and uploads `calendar.ics` + `events.json` as artifacts for troubleshooting.

--- a/src/pages/api/gallery/README.md
+++ b/src/pages/api/gallery/README.md
@@ -1,0 +1,29 @@
+# Gallery
+
+Photos and videos are stored in the `white-rabbit-gallery` Cloudflare R2 bucket and served from its public URL (`pub-acd9a4df04b04e13a687ac0f697b36c5.r2.dev`).
+
+## How the listing works
+
+`src/pages/gallery.astro` is an SSR page. On each request:
+
+1. Check the `SESSION` KV namespace for a cached listing under the key `gallery:listing`
+2. **Cache hit** → deserialize and render immediately (instant)
+3. **Cache miss** → paginate the Cloudflare R2 listing API, render, then write to KV in the background without blocking the response (TTL: 1 hour)
+
+The cold-cache path (first request after the TTL expires) takes ~10s for a large bucket. Every subsequent request within the hour is instant.
+
+## Forcing a cache refresh
+
+After uploading new photos, do one of:
+
+- Delete the `gallery:listing` key from the `SESSION` KV namespace in the Cloudflare dashboard
+- Wait for the 1-hour TTL to expire
+
+## Required env vars
+
+Set via `wrangler secret put`:
+
+| Variable | Description |
+|---|---|
+| `WHITE_RABBIT_ACCOUNT_ID` | Cloudflare account ID |
+| `WHITE_RABBIT_R2_API_TOKEN` | R2 API token with read access to `white-rabbit-gallery` |

--- a/src/pages/api/gallery/README.md
+++ b/src/pages/api/gallery/README.md
@@ -2,22 +2,38 @@
 
 Photos and videos are stored in the `white-rabbit-gallery` Cloudflare R2 bucket and served from its public URL (`pub-acd9a4df04b04e13a687ac0f697b36c5.r2.dev`).
 
-## How the listing works
+## Caching strategy
 
-`src/pages/gallery.astro` is an SSR page. On each request:
+`src/pages/gallery.astro` uses **stale-while-revalidate** backed by the `SESSION` KV namespace.
 
-1. Check the `SESSION` KV namespace for a cached listing under the key `gallery:listing`
-2. **Cache hit** → deserialize and render immediately (instant)
-3. **Cache miss** → paginate the Cloudflare R2 listing API, render, then write to KV in the background without blocking the response (TTL: 1 hour)
+Two KV keys:
 
-The cold-cache path (first request after the TTL expires) takes ~10s for a large bucket. Every subsequent request within the hour is instant.
+| Key | Value | TTL |
+|---|---|---|
+| `gallery:listing` | Full JSON listing of all items | None (permanent) |
+| `gallery:listing:fresh` | `"1"` freshness marker | 1 hour |
 
-## Forcing a cache refresh
+**On each request:**
 
-After uploading new photos, do one of:
+1. Read both keys in parallel
+2. **Warm cache** (both keys present) → render instantly, no background work
+3. **Stale cache** (listing present, freshness marker expired) → render instantly from stale data, refresh KV in the background via `ctx.waitUntil()` — user never waits
+4. **Cold cache** (no listing at all) → fetch from R2 API synchronously (~10s), then write to KV in background
 
-- Delete the `gallery:listing` key from the `SESSION` KV namespace in the Cloudflare dashboard
-- Wait for the 1-hour TTL to expire
+After the initial cold load, no user ever waits for the R2 API.
+
+## Purge endpoint
+
+`POST /api/gallery/purge` fetches a fresh listing from R2 and writes it to KV synchronously, so the very next gallery request is instant.
+
+**Auth:** Bearer token matched against the `GALLERY_PURGE_SECRET` env var.
+
+```bash
+curl -X POST https://whiterabbitwcs.com/api/gallery/purge \
+  -H "Authorization: Bearer $GALLERY_PURGE_SECRET"
+```
+
+Call this from the GitHub Actions workflow after uploading new photos (see issue #47).
 
 ## Required env vars
 
@@ -27,3 +43,4 @@ Set via `wrangler secret put`:
 |---|---|
 | `WHITE_RABBIT_ACCOUNT_ID` | Cloudflare account ID |
 | `WHITE_RABBIT_R2_API_TOKEN` | R2 API token with read access to `white-rabbit-gallery` |
+| `GALLERY_PURGE_SECRET` | Secret token for the purge endpoint |

--- a/src/pages/api/gallery/purge.ts
+++ b/src/pages/api/gallery/purge.ts
@@ -18,9 +18,15 @@ export const POST: APIRoute = async ({ request }) => {
   const apiToken   = e.WHITE_RABBIT_R2_API_TOKEN as string | undefined;
   const kv         = e.SESSION as { put: (k: string, v: string, o?: any) => Promise<void> } | undefined;
 
-  // Auth
+  // Auth — timing-safe comparison to prevent token oracle via response time
   const token = (request.headers.get("Authorization") ?? "").replace(/^Bearer\s+/i, "");
-  if (!secret || token !== secret) {
+  const enc = new TextEncoder();
+  const secretBytes = enc.encode(secret ?? "");
+  const tokenBytes  = enc.encode(token);
+  const valid = secret &&
+    secretBytes.byteLength === tokenBytes.byteLength &&
+    crypto.subtle.timingSafeEqual(secretBytes, tokenBytes);
+  if (!valid) {
     return new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401 });
   }
 

--- a/src/pages/api/gallery/purge.ts
+++ b/src/pages/api/gallery/purge.ts
@@ -1,0 +1,75 @@
+export const prerender = false;
+
+import type { APIRoute } from "astro";
+import { env as cfEnv } from "cloudflare:workers";
+
+const KV_KEY       = "gallery:listing";
+const KV_FRESH_KEY = "gallery:listing:fresh";
+const KV_FRESH_TTL = 3600;
+const BUCKET_NAME  = "white-rabbit-gallery";
+const PUBLIC_BUCKET_URL = "https://pub-acd9a4df04b04e13a687ac0f697b36c5.r2.dev";
+const VIDEO_EXTS = /\.(mp4|mov|webm)$/i;
+const IMAGE_EXTS = /\.(jpg|jpeg|png|gif|webp|avif)$/i;
+
+export const POST: APIRoute = async ({ request }) => {
+  const e = cfEnv as any;
+  const secret     = e.GALLERY_PURGE_SECRET as string | undefined;
+  const accountId  = e.WHITE_RABBIT_ACCOUNT_ID as string | undefined;
+  const apiToken   = e.WHITE_RABBIT_R2_API_TOKEN as string | undefined;
+  const kv         = e.SESSION as { put: (k: string, v: string, o?: any) => Promise<void> } | undefined;
+
+  // Auth
+  const token = (request.headers.get("Authorization") ?? "").replace(/^Bearer\s+/i, "");
+  if (!secret || token !== secret) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401 });
+  }
+
+  if (!accountId || !apiToken || !kv) {
+    return new Response(JSON.stringify({ error: "Missing configuration" }), { status: 503 });
+  }
+
+  // Fetch fresh listing from R2
+  const fetched: { key: string; url: string; name: string; album: string | null; isVideo: boolean; uploaded: string }[] = [];
+  let cursor: string | undefined;
+  do {
+    const url = new URL(
+      `https://api.cloudflare.com/client/v4/accounts/${accountId}/r2/buckets/${BUCKET_NAME}/objects`
+    );
+    if (cursor) url.searchParams.set("cursor", cursor);
+    url.searchParams.set("per_page", "1000");
+
+    const res = await fetch(url.toString(), {
+      headers: { Authorization: `Bearer ${apiToken}` },
+    });
+    if (!res.ok) {
+      return new Response(JSON.stringify({ error: `R2 API error: ${res.status}` }), { status: 502 });
+    }
+    const data = await res.json() as {
+      result: { key: string; last_modified: string }[];
+      result_info: { cursor: string; is_truncated: boolean };
+    };
+
+    for (const obj of data.result) {
+      if (!IMAGE_EXTS.test(obj.key) && !VIDEO_EXTS.test(obj.key)) continue;
+      const segments = obj.key.split("/");
+      const album = segments.length > 1 ? segments.slice(0, -1).join("/") : null;
+      fetched.push({
+        key: obj.key,
+        url: `${PUBLIC_BUCKET_URL}/${obj.key.split("/").map(encodeURIComponent).join("/")}`,
+        name: segments[segments.length - 1],
+        album,
+        isVideo: VIDEO_EXTS.test(obj.key),
+        uploaded: obj.last_modified,
+      });
+    }
+    cursor = data.result_info?.is_truncated ? data.result_info.cursor : undefined;
+  } while (cursor);
+
+  fetched.sort((a, b) => new Date(b.uploaded).getTime() - new Date(a.uploaded).getTime());
+
+  // Write to KV — next gallery request will be instant
+  await kv.put(KV_KEY, JSON.stringify(fetched));
+  await kv.put(KV_FRESH_KEY, "1", { expirationTtl: KV_FRESH_TTL });
+
+  return new Response(JSON.stringify({ ok: true, count: fetched.length }), { status: 200 });
+};

--- a/src/pages/gallery.astro
+++ b/src/pages/gallery.astro
@@ -87,9 +87,12 @@ if (accountId && apiToken) {
     items = (cached as GalleryItem[]).map(i => ({ ...i, uploaded: new Date(i.uploaded) }));
 
     if (!fresh) {
-      // Stale: refresh in background, user still gets instant response
+      // Stale: fetch and store entirely in background — user gets instant response
       const { ctx } = getRequestContext();
-      ctx.waitUntil(storeInKV(await fetchFromR2(accountId, apiToken)));
+      ctx.waitUntil((async () => {
+        const refreshed = await fetchFromR2(accountId, apiToken);
+        await storeInKV(refreshed);
+      })());
     }
   } else {
     // Cold cache: fetch synchronously (unavoidable on first ever load)

--- a/src/pages/gallery.astro
+++ b/src/pages/gallery.astro
@@ -1,20 +1,25 @@
 ---
 export const prerender = false;
 
-import { env as cfEnv } from "cloudflare:workers";
+import { env as cfEnv, getRequestContext } from "cloudflare:workers";
 import Layout from "../layouts/Layout.astro";
 
 const PUBLIC_BUCKET_URL = "https://pub-acd9a4df04b04e13a687ac0f697b36c5.r2.dev";
 const BUCKET_NAME = "white-rabbit-gallery";
 const VIDEO_EXTS = /\.(mp4|mov|webm)$/i;
 const IMAGE_EXTS = /\.(jpg|jpeg|png|gif|webp|avif)$/i;
-const KV_KEY = "gallery:listing";
-const KV_TTL = 3600;
+
+// Two KV keys:
+//   gallery:listing — the actual data, no TTL (permanent until explicitly purged)
+//   gallery:listing:fresh — empty marker with 1h TTL; missing = stale, triggers background refresh
+const KV_KEY       = "gallery:listing";
+const KV_FRESH_KEY = "gallery:listing:fresh";
+const KV_FRESH_TTL = 3600;
 
 const e = cfEnv as any;
 const accountId = e.WHITE_RABBIT_ACCOUNT_ID as string | undefined;
 const apiToken  = e.WHITE_RABBIT_R2_API_TOKEN as string | undefined;
-const kv        = e.SESSION as { get: (k: string, t: string) => Promise<any>; put: (k: string, v: string, o?: any) => Promise<void> } | undefined;
+const kv        = e.SESSION as { get: (k: string, t?: string) => Promise<any>; put: (k: string, v: string, o?: any) => Promise<void>; delete: (k: string) => Promise<void> } | undefined;
 
 type GalleryItem = {
   key: string;
@@ -25,7 +30,7 @@ type GalleryItem = {
   uploaded: Date;
 };
 
-async function fetchFromR2(): Promise<GalleryItem[]> {
+async function fetchFromR2(accountId: string, apiToken: string): Promise<GalleryItem[]> {
   const fetched: GalleryItem[] = [];
   let cursor: string | undefined;
   do {
@@ -64,17 +69,33 @@ async function fetchFromR2(): Promise<GalleryItem[]> {
   return fetched;
 }
 
+async function storeInKV(items: GalleryItem[]) {
+  if (!kv) return;
+  await kv.put(KV_KEY, JSON.stringify(items));
+  await kv.put(KV_FRESH_KEY, "1", { expirationTtl: KV_FRESH_TTL });
+}
+
 let items: GalleryItem[] = [];
 
 if (accountId && apiToken) {
-  const cached = kv ? await kv.get(KV_KEY, "json") as GalleryItem[] | null : null;
+  const [cached, fresh] = kv
+    ? await Promise.all([kv.get(KV_KEY, "json"), kv.get(KV_FRESH_KEY)])
+    : [null, null];
 
   if (cached) {
-    items = cached.map(i => ({ ...i, uploaded: new Date(i.uploaded) }));
+    // Always serve cached data immediately — never make the user wait
+    items = (cached as GalleryItem[]).map(i => ({ ...i, uploaded: new Date(i.uploaded) }));
+
+    if (!fresh) {
+      // Stale: refresh in background, user still gets instant response
+      const { ctx } = getRequestContext();
+      ctx.waitUntil(storeInKV(await fetchFromR2(accountId, apiToken)));
+    }
   } else {
-    items = await fetchFromR2();
-    // Store in KV; don't await so the response isn't held up on the write
-    kv?.put(KV_KEY, JSON.stringify(items), { expirationTtl: KV_TTL });
+    // Cold cache: fetch synchronously (unavoidable on first ever load)
+    items = await fetchFromR2(accountId, apiToken);
+    const { ctx } = getRequestContext();
+    ctx.waitUntil(storeInKV(items));
   }
 }
 

--- a/src/pages/gallery.astro
+++ b/src/pages/gallery.astro
@@ -1,16 +1,20 @@
 ---
 export const prerender = false;
 
+import { env as cfEnv } from "cloudflare:workers";
 import Layout from "../layouts/Layout.astro";
 
 const PUBLIC_BUCKET_URL = "https://pub-acd9a4df04b04e13a687ac0f697b36c5.r2.dev";
 const BUCKET_NAME = "white-rabbit-gallery";
 const VIDEO_EXTS = /\.(mp4|mov|webm)$/i;
 const IMAGE_EXTS = /\.(jpg|jpeg|png|gif|webp|avif)$/i;
+const KV_KEY = "gallery:listing";
+const KV_TTL = 3600;
 
-const env = (Astro.locals as any).runtime?.env;
-const accountId = env?.WHITE_RABBIT_ACCOUNT_ID;
-const apiToken = env?.WHITE_RABBIT_R2_API_TOKEN;
+const e = cfEnv as any;
+const accountId = e.WHITE_RABBIT_ACCOUNT_ID as string | undefined;
+const apiToken  = e.WHITE_RABBIT_R2_API_TOKEN as string | undefined;
+const kv        = e.SESSION as { get: (k: string, t: string) => Promise<any>; put: (k: string, v: string, o?: any) => Promise<void> } | undefined;
 
 type GalleryItem = {
   key: string;
@@ -21,16 +25,15 @@ type GalleryItem = {
   uploaded: Date;
 };
 
-let items: GalleryItem[] = [];
-
-if (accountId && apiToken) {
+async function fetchFromR2(): Promise<GalleryItem[]> {
+  const fetched: GalleryItem[] = [];
   let cursor: string | undefined;
   do {
     const url = new URL(
       `https://api.cloudflare.com/client/v4/accounts/${accountId}/r2/buckets/${BUCKET_NAME}/objects`
     );
     if (cursor) url.searchParams.set("cursor", cursor);
-    url.searchParams.set("per_page", "50");
+    url.searchParams.set("per_page", "1000");
 
     const res = await fetch(url.toString(), {
       headers: { Authorization: `Bearer ${apiToken}` },
@@ -45,7 +48,7 @@ if (accountId && apiToken) {
       const segments = obj.key.split("/");
       const album = segments.length > 1 ? segments.slice(0, -1).join("/") : null;
       const name = segments[segments.length - 1];
-      items.push({
+      fetched.push({
         key: obj.key,
         url: `${PUBLIC_BUCKET_URL}/${obj.key.split("/").map(encodeURIComponent).join("/")}`,
         name,
@@ -57,7 +60,22 @@ if (accountId && apiToken) {
     cursor = data.result_info?.is_truncated ? data.result_info.cursor : undefined;
   } while (cursor);
 
-  items.sort((a, b) => b.uploaded.getTime() - a.uploaded.getTime());
+  fetched.sort((a, b) => b.uploaded.getTime() - a.uploaded.getTime());
+  return fetched;
+}
+
+let items: GalleryItem[] = [];
+
+if (accountId && apiToken) {
+  const cached = kv ? await kv.get(KV_KEY, "json") as GalleryItem[] | null : null;
+
+  if (cached) {
+    items = cached.map(i => ({ ...i, uploaded: new Date(i.uploaded) }));
+  } else {
+    items = await fetchFromR2();
+    // Store in KV; don't await so the response isn't held up on the write
+    kv?.put(KV_KEY, JSON.stringify(items), { expirationTtl: KV_TTL });
+  }
 }
 
 // Group by album


### PR DESCRIPTION
Fixes the 10+ second gallery load time.

**Root cause**: every request paginated the Cloudflare R2 listing API (50 items/page) before rendering.

**Fix**:
- Cache the full listing in the `SESSION` KV namespace (`gallery:listing` key, 1-hour TTL)
- Cache hit → response is instant (KV read only)
- Cache miss → fetch from R2, store in KV without awaiting the write (response not blocked)
- Bumped `per_page` 50 → 1000 to minimize round trips on cold cache
- Migrated from deprecated `locals.runtime.env` to `cloudflare:workers` env import