### PR TITLE
fix: send Printify orders to production after creation

### DIFF
--- a/src/lib/printful.ts
+++ b/src/lib/printful.ts
@@ -42,12 +42,14 @@ export async function createPrintifyOrder(
   recipient: PrintifyOrderRecipient,
   items: { productId: string; variantId: number; quantity: number }[]
 ): Promise<void> {
-  const res = await fetch(`https://api.printify.com/v1/shops/${shopId}/orders.json`, {
+  const headers = {
+    Authorization: `Bearer ${apiToken}`,
+    'Content-Type': 'application/json',
+  };
+
+  const createRes = await fetch(`https://api.printify.com/v1/shops/${shopId}/orders.json`, {
     method: 'POST',
-    headers: {
-      Authorization: `Bearer ${apiToken}`,
-      'Content-Type': 'application/json',
-    },
+    headers,
     body: JSON.stringify({
       line_items: items.map(i => ({
         product_id: i.productId,
@@ -59,8 +61,20 @@ export async function createPrintifyOrder(
     }),
   });
 
-  if (!res.ok) {
-    const body = await res.text();
-    throw new Error(`Printify order failed: ${res.status} ${body}`);
+  if (!createRes.ok) {
+    const body = await createRes.text();
+    throw new Error(`Printify order create failed: ${createRes.status} ${body}`);
+  }
+
+  const order = await createRes.json() as { id: string };
+
+  const sendRes = await fetch(
+    `https://api.printify.com/v1/shops/${shopId}/orders/${order.id}/send_to_production.json`,
+    { method: 'POST', headers }
+  );
+
+  if (!sendRes.ok) {
+    const body = await sendRes.text();
+    throw new Error(`Printify send_to_production failed: ${sendRes.status} ${body}`);
   }
 }


### PR DESCRIPTION
Re-applies the send_to_production call that was reverted in e222186. Orders created via the webhook are now automatically submitted to production rather than left as drafts.