### PR TITLE
feat: add Coinbase Commerce crypto checkout

### DIFF
--- a/src/pages/api/coinbase-checkout.ts
+++ b/src/pages/api/coinbase-checkout.ts
@@ -1,0 +1,82 @@
+import type { APIContext } from 'astro';
+import { env as cfEnv } from 'cloudflare:workers';
+
+export const prerender = false;
+
+export async function POST({ request, locals }: APIContext) {
+  const env = (locals as { runtime?: { env?: Record<string, string> } }).runtime?.env ?? {};
+  const apiKey = env.COINBASE_COMMERCE_API_KEY;
+  if (!apiKey) return new Response('Coinbase Commerce not configured', { status: 500 });
+
+  const origin = request.headers.get('origin') ?? 'http://localhost:4321';
+  const kv = (cfEnv as unknown as Env).SESSION;
+
+  let body: {
+    productId: string;
+    variantId: number;
+    variantName: string;
+    price: string;
+    productName: string;
+    quantity?: number;
+    shipping: {
+      name: string;
+      email: string;
+      phone: string;
+      address1: string;
+      city: string;
+      state: string;
+      zip: string;
+    };
+  };
+
+  try {
+    body = await request.json();
+  } catch {
+    return new Response('Invalid JSON', { status: 400 });
+  }
+
+  const { productId, variantId, variantName, price, productName, quantity = 1, shipping } = body;
+  if (!variantId || !price || !productName || !shipping?.name || !shipping?.address1) {
+    return new Response('Missing required fields', { status: 400 });
+  }
+
+  const res = await fetch('https://api.commerce.coinbase.com/charges', {
+    method: 'POST',
+    headers: {
+      'X-CC-Api-Key': apiKey,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      name: productName,
+      description: variantName,
+      pricing_type: 'fixed_price',
+      local_price: {
+        amount: (parseFloat(price) * quantity).toFixed(2),
+        currency: 'USD',
+      },
+      metadata: {
+        printify_product_id: String(productId ?? ''),
+        printify_variant_id: String(variantId),
+        quantity: String(quantity),
+      },
+      redirect_url: `${origin}/shop/success`,
+      cancel_url: `${origin}/shop`,
+    }),
+  });
+
+  if (!res.ok) {
+    const err = await res.text();
+    console.error('[coinbase-checkout] Charge creation failed:', err);
+    return new Response('Charge creation failed', { status: 500 });
+  }
+
+  const { data } = await res.json() as { data: { code: string; hosted_url: string } };
+
+  if (kv) {
+    await kv.put(`coinbase_shipping:${data.code}`, JSON.stringify(shipping), { expirationTtl: 604800 });
+  }
+
+  return new Response(JSON.stringify({ url: data.hosted_url }), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+}

--- a/src/pages/api/coinbase-webhook.ts
+++ b/src/pages/api/coinbase-webhook.ts
@@ -1,0 +1,141 @@
+import type { APIContext } from 'astro';
+import { env as cfEnv } from 'cloudflare:workers';
+import { createPrintifyOrder } from '../../lib/printful';
+
+export const prerender = false;
+
+async function verifySignature(rawBody: string, signature: string, secret: string): Promise<boolean> {
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+  const sigBytes = await crypto.subtle.sign('HMAC', key, encoder.encode(rawBody));
+  const computed = Array.from(new Uint8Array(sigBytes))
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('');
+  if (computed.length !== signature.length) return false;
+  let diff = 0;
+  for (let i = 0; i < computed.length; i++) {
+    diff |= computed.charCodeAt(i) ^ signature.charCodeAt(i);
+  }
+  return diff === 0;
+}
+
+type CoinbaseEvent = {
+  id: string;
+  type: string;
+  data: {
+    code: string;
+    metadata?: {
+      printify_product_id?: string;
+      printify_variant_id?: string;
+      quantity?: string;
+    };
+  };
+};
+
+type ShippingInfo = {
+  name: string;
+  email: string;
+  phone: string;
+  address1: string;
+  city: string;
+  state: string;
+  zip: string;
+};
+
+export async function POST({ request, locals }: APIContext) {
+  const env = (locals as { runtime?: { env?: Record<string, string> } }).runtime?.env ?? {};
+  const webhookSecret = env.COINBASE_COMMERCE_WEBHOOK_SECRET;
+  const printifyToken = env.PRINTIFY_API_TOKEN;
+  const printifyShopId = env.PRINTIFY_SHOP_ID;
+  const kv = (cfEnv as unknown as Env).SESSION;
+
+  if (!webhookSecret || !printifyToken || !printifyShopId) {
+    return new Response('Missing env vars', { status: 500 });
+  }
+
+  const sig = request.headers.get('x-cc-webhook-signature');
+  if (!sig) return new Response('No signature', { status: 400 });
+
+  const rawBody = await request.text();
+
+  const valid = await verifySignature(rawBody, sig, webhookSecret);
+  if (!valid) return new Response('Invalid signature', { status: 400 });
+
+  let payload: { event: CoinbaseEvent };
+  try {
+    payload = JSON.parse(rawBody);
+  } catch {
+    return new Response('Invalid JSON', { status: 400 });
+  }
+
+  const { event } = payload;
+
+  if (event.type !== 'charge:confirmed') {
+    return new Response('OK', { status: 200 });
+  }
+
+  const idempotencyKey = `coinbase_event:${event.id}`;
+  if (kv) {
+    const already = await kv.get(idempotencyKey);
+    if (already) {
+      console.log(`[coinbase-webhook] Duplicate event ${event.id}, skipping`);
+      return new Response('OK', { status: 200 });
+    }
+  }
+
+  const { code, metadata } = event.data;
+  const productId = metadata?.printify_product_id ?? '';
+  const variantId = Number(metadata?.printify_variant_id);
+  const quantity = Number(metadata?.quantity ?? 1);
+
+  if (!productId || !variantId) {
+    console.error('[coinbase-webhook] Missing printify metadata');
+    return new Response('Missing variant', { status: 400 });
+  }
+
+  const shippingRaw = kv ? await kv.get(`coinbase_shipping:${code}`) : null;
+  if (!shippingRaw) {
+    console.error('[coinbase-webhook] No shipping info for charge', code);
+    return new Response('No shipping info', { status: 400 });
+  }
+
+  const shipping: ShippingInfo = JSON.parse(shippingRaw);
+  const nameParts = shipping.name.trim().split(' ');
+  const firstName = nameParts[0];
+  const lastName = nameParts.slice(1).join(' ') || '-';
+
+  try {
+    await createPrintifyOrder(
+      printifyToken,
+      printifyShopId,
+      {
+        first_name: firstName,
+        last_name: lastName,
+        email: shipping.email,
+        phone: shipping.phone || '0000000000',
+        address1: shipping.address1,
+        city: shipping.city,
+        region: shipping.state,
+        country: 'US',
+        zip: shipping.zip,
+      },
+      [{ productId, variantId, quantity, externalId: `coinbase:${code}` }]
+    );
+  } catch (err) {
+    console.error('[coinbase-webhook] Printify order failed:', err);
+    return new Response(`Printify error: ${err}`, { status: 500 });
+  }
+
+  if (kv) {
+    await kv.put(idempotencyKey, code, { expirationTtl: 604800 });
+  }
+
+  console.log(`[coinbase-webhook] Printify order created for charge ${code}`);
+  return new Response('OK', { status: 200 });
+}

--- a/src/pages/shop.astro
+++ b/src/pages/shop.astro
@@ -101,10 +101,32 @@ const products = productsData as Product[];
 
           <div class="dialog-price" id="dialog-price"></div>
 
-          <div class="dialog-actions">
+          <div class="dialog-actions" id="dialog-actions">
             <button class="btn-buy" id="btn-stripe">
               Buy Now
             </button>
+            <button class="btn-crypto" id="btn-crypto">
+              Pay with Crypto
+            </button>
+          </div>
+
+          <div id="crypto-shipping-form" hidden>
+            <p class="form-section-label">Shipping address</p>
+            <div class="form-fields">
+              <input class="form-input" id="crypto-name" placeholder="Full name" autocomplete="name" />
+              <input class="form-input" id="crypto-email" type="email" placeholder="Email" autocomplete="email" />
+              <input class="form-input" id="crypto-address" placeholder="Street address" autocomplete="street-address" />
+              <div class="form-row">
+                <input class="form-input" id="crypto-city" placeholder="City" autocomplete="address-level2" />
+                <input class="form-input form-input--sm" id="crypto-state" placeholder="State" maxlength="2" autocomplete="address-level1" />
+                <input class="form-input form-input--sm" id="crypto-zip" placeholder="ZIP" maxlength="10" autocomplete="postal-code" />
+              </div>
+              <input class="form-input" id="crypto-phone" type="tel" placeholder="Phone (optional)" autocomplete="tel" />
+            </div>
+            <div class="form-actions">
+              <button class="btn-back" id="btn-crypto-back" type="button">← Back</button>
+              <button class="btn-buy" id="btn-crypto-submit" type="button">Continue to Crypto →</button>
+            </div>
           </div>
 
           <p class="dialog-note" id="dialog-error" role="alert"></p>
@@ -129,6 +151,18 @@ const products = productsData as Product[];
   const colorGroup = document.getElementById('color-group') as HTMLElement;
   const sizeGroup = document.getElementById('size-group') as HTMLElement;
   const btnStripe = document.getElementById('btn-stripe') as HTMLButtonElement;
+  const btnCrypto = document.getElementById('btn-crypto') as HTMLButtonElement;
+  const btnCryptoBack = document.getElementById('btn-crypto-back') as HTMLButtonElement;
+  const btnCryptoSubmit = document.getElementById('btn-crypto-submit') as HTMLButtonElement;
+  const dialogActions = document.getElementById('dialog-actions') as HTMLElement;
+  const cryptoForm = document.getElementById('crypto-shipping-form') as HTMLElement;
+  const cryptoName = document.getElementById('crypto-name') as HTMLInputElement;
+  const cryptoEmail = document.getElementById('crypto-email') as HTMLInputElement;
+  const cryptoAddress = document.getElementById('crypto-address') as HTMLInputElement;
+  const cryptoCity = document.getElementById('crypto-city') as HTMLInputElement;
+  const cryptoState = document.getElementById('crypto-state') as HTMLInputElement;
+  const cryptoZip = document.getElementById('crypto-zip') as HTMLInputElement;
+  const cryptoPhone = document.getElementById('crypto-phone') as HTMLInputElement;
   const dialogError = document.getElementById('dialog-error') as HTMLElement;
 
   let currentProduct: Product | null = null;
@@ -239,6 +273,24 @@ const products = productsData as Product[];
   });
   sizeSelect.addEventListener('change', () => { selectedSize = sizeSelect.value; updateDialog(); });
 
+  function showCryptoForm() {
+    dialogSelectors.hidden = true;
+    dialogPrice.hidden = true;
+    dialogActions.hidden = true;
+    dialogDesc.hidden = true;
+    cryptoForm.hidden = false;
+    dialogError.textContent = '';
+  }
+
+  function hideCryptoForm() {
+    cryptoForm.hidden = true;
+    dialogSelectors.hidden = false;
+    dialogPrice.hidden = false;
+    dialogActions.hidden = false;
+    dialogDesc.hidden = false;
+    dialogError.textContent = '';
+  }
+
   function openProduct(product: Product) {
     currentProduct = product;
     const blackVariant = product.variants.find(v => v.color?.toLowerCase() === 'black');
@@ -253,6 +305,7 @@ const products = productsData as Product[];
     renderThumbs(getImagesForColor(selectedColor), 0);
     updateDialog();
 
+    hideCryptoForm();
     dialog.showModal();
     document.body.style.overflow = "hidden";
     document.documentElement.style.overflow = "hidden";
@@ -274,6 +327,62 @@ const products = productsData as Product[];
     (document.activeElement as HTMLElement)?.blur();
     document.body.style.overflow = "";
     document.documentElement.style.overflow = "";
+  });
+
+  btnCrypto?.addEventListener('click', () => showCryptoForm());
+  btnCryptoBack?.addEventListener('click', () => hideCryptoForm());
+
+  btnCryptoSubmit?.addEventListener('click', async () => {
+    const variant = getVariant();
+    if (!variant || !currentProduct) return;
+
+    const name = cryptoName.value.trim();
+    const email = cryptoEmail.value.trim();
+    const address1 = cryptoAddress.value.trim();
+    const city = cryptoCity.value.trim();
+    const state = cryptoState.value.trim();
+    const zip = cryptoZip.value.trim();
+
+    if (!name || !email || !address1 || !city || !state || !zip) {
+      dialogError.textContent = 'Please fill in all required shipping fields.';
+      return;
+    }
+
+    btnCryptoSubmit.disabled = true;
+    btnCryptoSubmit.textContent = 'Redirecting…';
+    dialogError.textContent = '';
+
+    try {
+      const res = await fetch('/api/coinbase-checkout', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          productId: currentProduct.id,
+          variantId: variant.id,
+          variantName: variant.name,
+          price: variant.price,
+          productName: currentProduct.name,
+          quantity: 1,
+          shipping: {
+            name,
+            email,
+            phone: cryptoPhone.value.trim(),
+            address1,
+            city,
+            state,
+            zip,
+          },
+        }),
+      });
+
+      const { url } = await res.json();
+      if (url) window.location.href = url;
+      else throw new Error('No checkout URL returned');
+    } catch {
+      dialogError.textContent = 'Something went wrong. Please try again.';
+      btnCryptoSubmit.disabled = false;
+      btnCryptoSubmit.textContent = 'Continue to Crypto →';
+    }
   });
 
   btnStripe?.addEventListener('click', async () => {
@@ -656,5 +765,106 @@ const products = productsData as Product[];
     margin: 0;
     min-height: 1.2em;
     font-family: var(--font-secondary);
+  }
+
+  .btn-crypto {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 12px 24px;
+    border: 2px solid var(--border-color);
+    background: transparent;
+    color: var(--text-secondary);
+    font-family: var(--font-secondary);
+    font-size: 0.9rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: border-color 0.2s, color 0.2s;
+    width: 100%;
+    letter-spacing: 0.04em;
+  }
+
+  .btn-crypto:hover {
+    border-color: var(--accent-primary);
+    color: var(--accent-primary);
+  }
+
+  /* Crypto shipping form */
+  #crypto-shipping-form {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .form-section-label {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-muted);
+    font-family: var(--font-secondary);
+    margin: 0;
+  }
+
+  .form-fields {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .form-row {
+    display: flex;
+    gap: 8px;
+  }
+
+  .form-input {
+    width: 100%;
+    padding: 8px 12px;
+    background: var(--bg-primary);
+    border: 1px solid var(--border-color);
+    color: var(--text-primary);
+    font-family: var(--font-secondary);
+    font-size: 0.9rem;
+    transition: border-color 0.15s;
+    box-sizing: border-box;
+  }
+
+  .form-input:focus {
+    outline: none;
+    border-color: var(--accent-primary);
+  }
+
+  .form-input::placeholder {
+    color: var(--text-muted);
+  }
+
+  .form-input--sm {
+    width: 80px;
+    flex-shrink: 0;
+  }
+
+  .form-actions {
+    display: flex;
+    gap: 8px;
+  }
+
+  .btn-back {
+    padding: 12px 16px;
+    border: 1px solid var(--border-color);
+    background: transparent;
+    color: var(--text-muted);
+    font-family: var(--font-secondary);
+    font-size: 0.85rem;
+    cursor: pointer;
+    transition: color 0.15s, border-color 0.15s;
+    flex-shrink: 0;
+  }
+
+  .btn-back:hover {
+    color: var(--text-primary);
+    border-color: var(--text-secondary);
+  }
+
+  .form-actions .btn-buy {
+    flex: 1;
   }
 </style>


### PR DESCRIPTION
## Summary

- Adds a second payment path in the shop alongside Stripe — customers can pay with crypto via Coinbase's hosted checkout
- Because Coinbase Commerce doesn't collect shipping info, clicking "Pay with Crypto" reveals an inline shipping form in the product dialog before redirecting
- Shipping is stored in the `SESSION` KV namespace keyed by the charge code and retrieved in the webhook handler when creating the Printify order
- Webhook signature verification uses HMAC-SHA256 (`X-CC-Webhook-Signature`) via Web Crypto API — same pattern as the Stripe webhook
- Idempotency key stored in KV (`coinbase_event:{id}`) prevents duplicate Printify orders on webhook retries

## New files

| File | Purpose |
|------|---------|
| `src/pages/api/coinbase-checkout.ts` | Creates Coinbase charge, stores shipping in KV, returns `hosted_url` |
| `src/pages/api/coinbase-webhook.ts` | Verifies signature, handles `charge:confirmed`, creates Printify order |

## Test plan

- [ ] Add env vars via `wrangler secret put` (see your todo below)
- [ ] Register webhook URL in Coinbase Commerce dashboard: `https://whiterabbitwcs.com/api/coinbase-webhook`
- [ ] Place a test order using a Coinbase Commerce test charge
- [ ] Confirm Printify draft order appears after `charge:confirmed` webhook fires
- [ ] Confirm duplicate webhook delivery is safely skipped