### PR TITLE
fix: replace innerHTML with safe DOM construction in gallery lightbox

### DIFF
--- a/src/pages/gallery.astro
+++ b/src/pages/gallery.astro
@@ -209,9 +209,21 @@ Astro.response.headers.set("Cache-Control", "public, max-age=3600, s-maxage=8640
   function show(index: number) {
     currentIndex = (index + items.length) % items.length;
     const { url, isVideo, label } = items[currentIndex];
-    mediaEl.innerHTML = isVideo
-      ? `<video src="${url}" controls autoplay playsinline aria-label="${label}"></video>`
-      : `<img src="${url}" alt="${label}" />`;
+    mediaEl.replaceChildren();
+    if (isVideo) {
+      const vid = document.createElement('video');
+      vid.src = url;
+      vid.controls = true;
+      vid.autoplay = true;
+      vid.playsInline = true;
+      vid.setAttribute('aria-label', label);
+      mediaEl.appendChild(vid);
+    } else {
+      const img = document.createElement('img');
+      img.src = url;
+      img.alt = label;
+      mediaEl.appendChild(img);
+    }
     lightbox.setAttribute("aria-label", `Image viewer — ${label} (${currentIndex + 1} of ${items.length})`);
     prevBtn.style.display = items.length > 1 ? "" : "none";
     nextBtn.style.display = items.length > 1 ? "" : "none";


### PR DESCRIPTION
## Summary

- The gallery lightbox built its `<video>` and `<img>` elements by interpolating `url` and `label` directly into an `innerHTML` template
- A filename containing a double-quote (e.g. `photo" onload="alert(1)`) could break out of an attribute and inject JavaScript, executable for all gallery visitors
- `label` comes from the R2 object key filename with no escaping

## Changes

Replaced the two-line `innerHTML` assignment in `show()` with `createElement` + direct property/attribute assignment (`img.alt`, `vid.setAttribute('aria-label', ...)`, `el.src`), so the label is never interpreted as HTML.