### PR TITLE
feat: meta and structured data improvements

### DIFF
--- a/src/components/SEO.astro
+++ b/src/components/SEO.astro
@@ -14,7 +14,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 const {
   title = "White Rabbit - Arizona WCS",
   description = "Follow the white rabbit into Arizona's West Coast Swing scene. Find events across Phoenix, Tucson, Prescott and beyond. Connect with dancers and discover your flow.",
-  image = "/og-image.jpg",
+  image = "/logo.webp",
   type = "website",
   publishedTime,
   modifiedTime,

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -24,7 +24,7 @@ export function generateOrganizationSchema() {
     },
     sameAs: [
       "https://www.instagram.com/whiterabbit.wcs/",
-      // Add other social media URLs here
+      "https://www.facebook.com/whiterabbitwcs",
     ],
   };
 }
@@ -137,6 +137,28 @@ export function generateVenueSchema(venue: {
       : undefined,
     telephone: venue.phone,
     url: venue.website,
+  };
+}
+
+/**
+ * Generate WebSite schema with SearchAction
+ */
+export function generateWebSiteSchema() {
+  return {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    name: "White Rabbit WCS",
+    url: "https://whiterabbitwcs.com",
+    description:
+      "Arizona's West Coast Swing dance community. Find WCS events, socials, workshops, and connect with dancers across Phoenix, Tucson, and Prescott.",
+    potentialAction: {
+      "@type": "SearchAction",
+      target: {
+        "@type": "EntryPoint",
+        urlTemplate: "https://whiterabbitwcs.com/events?q={search_term_string}",
+      },
+      "query-input": "required name=search_term_string",
+    },
   };
 }
 

--- a/src/pages/events.astro
+++ b/src/pages/events.astro
@@ -3,7 +3,7 @@ import Layout from '../layouts/Layout.astro';
 import EventCard from '../components/EventCard.astro';
 import MonthCalendar from '../components/MonthCalendar.astro';
 import { fetchGoogleCalendarEvents, type CalendarEvent } from '../lib/calendar';
-import { generateEventListSchema } from '../lib/schema';
+import { generateEventListSchema, generateBreadcrumbSchema } from '../lib/schema';
 // Fetch events from Google Calendar
 let events: CalendarEvent[] = [];
 let calendarError: string | null = null;
@@ -27,7 +27,13 @@ const pastEvents = events
   .filter(e => e.date < today)
   .sort((a, b) => b.date.localeCompare(a.date) || b.startTime.localeCompare(a.startTime));
 
-const schema = generateEventListSchema(upcomingEvents);
+const schema = [
+  generateEventListSchema(upcomingEvents),
+  generateBreadcrumbSchema([
+    { name: "Home", url: "https://whiterabbitwcs.com" },
+    { name: "Events", url: "https://whiterabbitwcs.com/events" },
+  ]),
+];
 
 
 ---

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,10 +4,10 @@ import { join } from "path";
 import Layout from "../layouts/Layout.astro";
 import RecentPosts from "../components/RecentPosts.astro";
 import FeedbackForm from "../components/FeedbackForm.astro";
-import { generateOrganizationSchema } from "../lib/schema";
+import { generateOrganizationSchema, generateWebSiteSchema } from "../lib/schema";
 import { getEntry } from "astro:content";
 
-const schema = generateOrganizationSchema();
+const schema = [generateOrganizationSchema(), generateWebSiteSchema()];
 const homeData = await getEntry("pages", "home");
 const heroImages = (homeData?.data.heroImages?.filter((i) => i.image) ?? []).map((item) => {
   const base = item.image.replace(/\.(png|jpe?g|webp)$/i, "");


### PR DESCRIPTION
## Summary

- **Broken OG image fixed** — `/og-image.jpg` was the default fallback but the file doesn't exist; swapped to `/logo.webp` so every shared link has a valid image
- **Multi-schema support** — `SEO` and `Layout` components now accept `schema?: object | object[]`, enabling multiple JSON-LD blocks per page
- **WebSite schema** — added `generateWebSiteSchema()` to `schema.ts` with a `SearchAction`; injected alongside Organization on the homepage so Google understands the site's search capability
- **BreadcrumbList on events page** — `generateBreadcrumbSchema()` already existed but was never called; now wired up on `/events`
- **Facebook added to `sameAs`** — Organization schema only had Instagram; added the Facebook page