### PR TITLE
feat: add FAQPage schema to about and community pages

### DIFF
--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -185,6 +185,24 @@ export function generateProductSchema(product: {
 }
 
 /**
+ * Generate FAQPage schema
+ */
+export function generateFAQSchema(faqs: Array<{ question: string; answer: string }>) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: faqs.map(({ question, answer }) => ({
+      "@type": "Question",
+      name: question,
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: answer,
+      },
+    })),
+  };
+}
+
+/**
  * Generate BreadcrumbList schema for navigation
  */
 export function generateBreadcrumbSchema(items: Array<{ name: string; url: string }>) {

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,8 +1,28 @@
 ---
 import Layout from "../layouts/Layout.astro";
-import { generateOrganizationSchema } from "../lib/schema";
+import { generateOrganizationSchema, generateFAQSchema } from "../lib/schema";
 
-const schema = generateOrganizationSchema();
+const schema = [
+  generateOrganizationSchema(),
+  generateFAQSchema([
+    {
+      question: "What is White Rabbit WCS?",
+      answer: "White Rabbit WCS (The White Rabbit Society) is Arizona's premier West Coast Swing dance community, based in Phoenix. Founded after COVID restrictions lifted, it grew from intimate home socials into Arizona's largest monthly WCS event, hosting 200+ dancers. It is led by three Event Directors — Joe Herrington, Sarah Hightower, and Travis Swartzlander.",
+    },
+    {
+      question: "Where does White Rabbit WCS hold events?",
+      answer: "White Rabbit WCS hosts events primarily in the Phoenix metro area, with events also in Tucson and Prescott. The monthly social is their flagship event. Find the full schedule at whiterabbitwcs.com/events.",
+    },
+    {
+      question: "Is White Rabbit WCS open to beginners?",
+      answer: "Yes. White Rabbit WCS welcomes all levels — from first-timers to seasoned competitors. Their code of conduct emphasizes a safe, inclusive space for everyone regardless of dance background or experience level.",
+    },
+    {
+      question: "How do I contact White Rabbit WCS?",
+      answer: "You can reach White Rabbit WCS by email at whiterabbitwcs@gmail.com, or follow them on Instagram at @whiterabbit.wcs and on Facebook at facebook.com/whiterabbitwcs.",
+    },
+  ]),
+];
 ---
 
 <Layout

--- a/src/pages/community.astro
+++ b/src/pages/community.astro
@@ -1,9 +1,33 @@
 ---
 import Layout from "../layouts/Layout.astro";
-import { generateOrganizationSchema } from "../lib/schema";
+import { generateOrganizationSchema, generateFAQSchema } from "../lib/schema";
 import { getCollection, getEntry } from "astro:content";
 
-const schema = generateOrganizationSchema();
+const schema = [
+  generateOrganizationSchema(),
+  generateFAQSchema([
+    {
+      question: "What do I need to start West Coast Swing dancing?",
+      answer: "Very little — comfortable clothes and a willingness to learn. For footwear, suede-soled dance shoes are the standard (look for low heels with a flexible sole), but beginners often start in smooth-soled street shoes. Most importantly, just show up to a social or beginner class.",
+    },
+    {
+      question: "What shoes should I wear for West Coast Swing?",
+      answer: "Suede-soled dance shoes are recommended for WCS. Popular brands include Very Fine, Ray Rose, and Freed of London. Avoid rubber-soled shoes as they grip the floor too much. Discount Dance Supply and Dance Naturals carry WCS-appropriate shoes online.",
+    },
+    {
+      question: "Where can I take West Coast Swing lessons in Arizona?",
+      answer: "Arizona has a strong WCS teaching community. The White Rabbit Society community page lists local instructors across Phoenix, Scottsdale, and Tempe. Classes range from beginner drop-ins to advanced workshops.",
+    },
+    {
+      question: "Where can I dance West Coast Swing in Phoenix?",
+      answer: "White Rabbit WCS hosts the largest monthly West Coast Swing social in Arizona, plus regular classes and workshops throughout the Phoenix metro. Check whiterabbitwcs.com/events for the full schedule of socials, workshops, and competitions.",
+    },
+    {
+      question: "What is the West Coast Swing Dance Council (WSDC)?",
+      answer: "The WSDC (West Coast Swing Dance Council) is the official governing body for competitive West Coast Swing. It maintains the points registry used at sanctioned competitions worldwide. Competitive dancers accumulate WSDC points to move up in division rankings.",
+    },
+  ]),
+];
 
 const DUMMY_INSTRUCTORS = [
   { name: "Sarah M.", level: "Advanced / Pro", specialties: ["Footwork", "Connection", "Musicality"], location: "Phoenix" },


### PR DESCRIPTION
## Summary

FAQPage schema is the single biggest AEO lever — AI answer engines (Google AI Overviews, Perplexity, ChatGPT) and classic featured snippets pull directly from `Question`/`Answer` markup. Adding this to the two most content-rich pages gives the site a strong signal for "what is WCS", "where to dance in Phoenix", and "how to get started" queries.

## Changes

- **`schema.ts`** — `generateFAQSchema(faqs)` utility that produces a valid `FAQPage` JSON-LD block
- **`about.astro`** — 4 FAQs: what is White Rabbit WCS, where events are held, whether beginners are welcome, how to contact
- **`community.astro`** — 5 FAQs: what you need to start WCS, what shoes to wear, where to take lessons in AZ, where to dance in Phoenix, what the WSDC is
- **`SEO.astro` + `Layout.astro`** — `schema` prop widened to `object | object[]` so multiple JSON-LD blocks can be emitted per page (also in PR #63 — whichever merges first wins)

## Note

The FAQ answers are written from page content and public knowledge about the org. Review them for accuracy — especially venue details, instructor names, and any claims that may have changed.