### PR TITLE
fix: remove empty heroImages entry that fails schema validation

### DIFF
--- a/src/content/pages/home.yaml
+++ b/src/content/pages/home.yaml
@@ -34,7 +34,6 @@ heroImages:
   - image: /images/hero/heroImages/32/image.webp
   - image: /images/hero/heroImages/33/image.webp
   - image: /images/hero/heroImages/34/image.webp
-  - {}
   - image: /images/hero/heroImages/36/image.webp
   - image: /images/hero/heroImages/37/image.webp
   - image: /images/hero/heroImages/38/image.webp


### PR DESCRIPTION
## Summary

- Removes a blank `{}` entry at index 35 in `src/content/pages/home.yaml` that was causing a build failure with `InvalidContentEntryDataError: heroImages.35.image: Required`
- The entry had no associated image file — it was an empty Keystatic save with no upload

## Root cause

Someone saved the home page in Keystatic without uploading an image for a new hero image slot, leaving a `{}` placeholder that fails the collection schema's required `image` field.