### PR TITLE
fix: require image upload before saving hero image slot in Keystatic

### DIFF
--- a/keystatic.config.ts
+++ b/keystatic.config.ts
@@ -38,6 +38,7 @@ export default config({
               label: "Image",
               directory: "public/images/hero",
               publicPath: "/images/hero/",
+              validation: { isRequired: true },
             }),
             alt: fields.text({ label: "Alt text" }),
           }),


### PR DESCRIPTION
## Summary

Adds `validation: { isRequired: true }` to the hero image field in the Keystatic config. Previously, adding a new image slot and saving without uploading produced an empty `{}` entry in `home.yaml`, which passes Keystatic's own validation but fails Astro's content collection schema at build time — breaking the deploy.

Now the Keystatic UI will block saving and show an error if a slot has no image attached.