### PR TITLE
feat: add website field to DJ info cards

### DIFF
--- a/keystatic.config.ts
+++ b/keystatic.config.ts
@@ -38,6 +38,7 @@ export default config({
               label: "Image",
               directory: "public/images/hero",
               publicPath: "/images/hero/",
+              validation: { isRequired: true },
             }),
             alt: fields.text({ label: "Alt text" }),
           }),

--- a/keystatic.config.ts
+++ b/keystatic.config.ts
@@ -166,6 +166,7 @@ export default config({
           directory: "public/images/djs",
           publicPath: "/images/djs/",
         }),
+        website: fields.url({ label: "Website", validation: { isRequired: false } }),
         spotify: fields.url({ label: "Spotify", validation: { isRequired: false } }),
         mixcloud: fields.url({ label: "Mixcloud", validation: { isRequired: false } }),
         soundcloud: fields.url({ label: "SoundCloud", validation: { isRequired: false } }),

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -54,6 +54,7 @@ const djs = defineCollection({
     style: z.array(z.string()).default([]),
     resident: z.boolean().default(false),
     photo: z.string().optional(),
+    website: z.string().url().optional(),
     spotify: z.string().url().optional(),
     mixcloud: z.string().url().optional(),
     soundcloud: z.string().url().optional(),

--- a/src/pages/music.astro
+++ b/src/pages/music.astro
@@ -96,8 +96,17 @@ function toSpotifyEmbed(url: string): string {
                     <span class="tag">{s}</span>
                   ))}
                 </div>
-                {(dj.instagram || dj.spotify || dj.mixcloud || dj.soundcloud) && (
+                {(dj.website || dj.instagram || dj.spotify || dj.mixcloud || dj.soundcloud) && (
                   <div class="dj-links">
+                    {dj.website && (
+                      <a href={dj.website} class="dj-link" target="_blank" rel="noopener noreferrer" aria-label="Website">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                          <circle cx="12" cy="12" r="10"/>
+                          <line x1="2" y1="12" x2="22" y2="12"/>
+                          <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/>
+                        </svg>
+                      </a>
+                    )}
                     {dj.instagram && (
                       <a href={`https://instagram.com/${dj.instagram.replace(/^@/, "")}`} class="dj-link" target="_blank" rel="noopener noreferrer" aria-label="Instagram">
                         <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">


### PR DESCRIPTION
## Summary

- Adds optional `website` URL field to the DJ Keystatic schema and Zod content schema
- Renders a globe icon link on DJ cards when a website is set, before the other social links

Closes #68