### PR TITLE
fix: use createElement in lightbox to prevent HTML injection via filenames

### DIFF
--- a/src/pages/gallery.astro
+++ b/src/pages/gallery.astro
@@ -209,9 +209,20 @@ Astro.response.headers.set("Cache-Control", "public, max-age=3600, s-maxage=8640
   function show(index: number) {
     currentIndex = (index + items.length) % items.length;
     const { url, isVideo, label } = items[currentIndex];
-    mediaEl.innerHTML = isVideo
-      ? `<video src="${url}" controls autoplay playsinline aria-label="${label}"></video>`
-      : `<img src="${url}" alt="${label}" />`;
+    mediaEl.innerHTML = "";
+    const el = isVideo
+      ? Object.assign(document.createElement("video"), {
+          src: url,
+          controls: true,
+          autoplay: true,
+          playsInline: true,
+        })
+      : Object.assign(document.createElement("img"), {
+          src: url,
+          alt: label,
+        });
+    if (isVideo) el.setAttribute("aria-label", label);
+    mediaEl.appendChild(el);
     lightbox.setAttribute("aria-label", `Image viewer — ${label} (${currentIndex + 1} of ${items.length})`);
     prevBtn.style.display = items.length > 1 ? "" : "none";
     nextBtn.style.display = items.length > 1 ? "" : "none";

--- a/src/pages/gallery.astro
+++ b/src/pages/gallery.astro
@@ -209,20 +209,19 @@ Astro.response.headers.set("Cache-Control", "public, max-age=3600, s-maxage=8640
   function show(index: number) {
     currentIndex = (index + items.length) % items.length;
     const { url, isVideo, label } = items[currentIndex];
-    mediaEl.innerHTML = "";
     const el = isVideo
       ? Object.assign(document.createElement("video"), {
           src: url,
           controls: true,
           autoplay: true,
           playsInline: true,
+          ariaLabel: label,
         })
       : Object.assign(document.createElement("img"), {
           src: url,
           alt: label,
         });
-    if (isVideo) el.setAttribute("aria-label", label);
-    mediaEl.appendChild(el);
+    mediaEl.replaceChildren(el);
     lightbox.setAttribute("aria-label", `Image viewer — ${label} (${currentIndex + 1} of ${items.length})`);
     prevBtn.style.display = items.length > 1 ? "" : "none";
     nextBtn.style.display = items.length > 1 ? "" : "none";


### PR DESCRIPTION
## Summary

- Replaces `innerHTML` template-literal injection in the lightbox `show()` function with `document.createElement` + property assignment
- Filenames (used as `alt`/`aria-label`) with characters like `"` would silently break the injected HTML, causing the lightbox to fail silently — the suspected crash vector in #70

## Test plan

- [ ] Open gallery, click a photo — lightbox should open as before
- [ ] Navigate prev/next with arrow buttons and keyboard
- [ ] Test with a video item if available
- [ ] Close with Escape and close button