### PR TITLE
feat: report gallery client-side errors to CF Workers logs

### DIFF
--- a/src/pages/api/client-error.ts
+++ b/src/pages/api/client-error.ts
@@ -1,0 +1,25 @@
+import type { APIContext } from "astro";
+
+export const prerender = false;
+
+export async function POST({ request }: APIContext) {
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return new Response(null, { status: 200 });
+  }
+
+  const { message, source, lineno, colno, stack, page } = body as {
+    message?: string;
+    source?: string;
+    lineno?: number;
+    colno?: number;
+    stack?: string;
+    page?: string;
+  };
+
+  console.error("[client-error]", JSON.stringify({ message, source, lineno, colno, stack, page }));
+
+  return new Response(null, { status: 200 });
+}

--- a/src/pages/gallery.astro
+++ b/src/pages/gallery.astro
@@ -174,6 +174,21 @@ Astro.response.headers.set("Cache-Control", "public, max-age=3600, s-maxage=8640
 </Layout>
 
 <script>
+  function reportError(payload: Record<string, unknown>) {
+    const data = JSON.stringify({ ...payload, page: window.location.pathname });
+    navigator.sendBeacon("/api/client-error", new Blob([data], { type: "application/json" }));
+  }
+
+  window.onerror = (message, source, lineno, colno, error) => {
+    reportError({ message: String(message), source, lineno, colno, stack: error?.stack });
+    return false;
+  };
+
+  window.addEventListener("unhandledrejection", (e) => {
+    const err = e.reason instanceof Error ? e.reason : null;
+    reportError({ message: err?.message ?? String(e.reason), stack: err?.stack });
+  });
+
   const lightbox = document.getElementById("lightbox")!;
   const mediaEl = document.getElementById("lightbox-media")!;
   const closeBtn = document.getElementById("lightbox-close") as HTMLButtonElement;

--- a/src/pages/gallery.astro
+++ b/src/pages/gallery.astro
@@ -254,20 +254,17 @@ Astro.response.headers.set("Cache-Control", "public, max-age=3600, s-maxage=8640
     triggerEl = null;
   }
 
-  // Load images inside a <details> when it's opened
-  function loadMedia(container: Element) {
-    container.querySelectorAll<HTMLImageElement | HTMLVideoElement>("[data-src]").forEach(el => {
-      if (!el.getAttribute("src")) {
-        el.setAttribute("src", el.dataset.src!);
-        el.removeAttribute("data-src");
-      }
-    });
-  }
+  const mediaObserver = new IntersectionObserver((entries) => {
+    for (const entry of entries) {
+      if (!entry.isIntersecting) continue;
+      const el = entry.target as HTMLImageElement | HTMLVideoElement;
+      el.src = el.dataset.src!;
+      el.removeAttribute("data-src");
+      mediaObserver.unobserve(el);
+    }
+  }, { rootMargin: "300px" });
 
-  document.querySelectorAll("details").forEach(details => {
-    if (details.open) loadMedia(details);
-    details.addEventListener("toggle", () => { if (details.open) loadMedia(details); });
-  });
+  document.querySelectorAll<HTMLImageElement | HTMLVideoElement>("[data-src]").forEach(el => mediaObserver.observe(el));
 
   gridItems.forEach((btn, i) => {
     btn.addEventListener("click", () => open(i, btn));


### PR DESCRIPTION
## Summary

- Adds `window.onerror` and `unhandledrejection` handlers to the gallery page that beacon error details (message, source, line/col, stack trace, page path) to a new `/api/client-error` endpoint
- The endpoint logs them via `console.error` into Cloudflare Workers observability (already enabled in `wrangler.jsonc`)
- Uses `navigator.sendBeacon` — fire-and-forget, won't block the page or interfere with normal behavior
- **Fixes gallery crash on iOS Safari**: replaces bulk `loadMedia()` (which swapped all `data-src` → `src` at once on accordion open) with an `IntersectionObserver` that loads each image only as it scrolls into view — prevents the ~375MB memory spike that was crashing Safari on albums with 150+ photos

## Test plan

- [ ] Open gallery, expand an album — images should load progressively as you scroll, not all at once
- [ ] Open gallery page locally, trigger a JS error in the console, verify POST hits `/api/client-error`
- [ ] Confirm `sendBeacon` fires on unhandled promise rejections too
- [ ] Deploy and confirm errors appear in Cloudflare Workers logs dashboard under the `[client-error]` prefix