### PR TITLE
fix: remove invalid website value from dj-bul breaking build

### DIFF
--- a/src/content/djs/dj-bul.yaml
+++ b/src/content/djs/dj-bul.yaml
@@ -11,6 +11,5 @@ bio: >-
 style: []
 resident: true
 photo: /images/djs/dj-bul/photo.png
-website: test.com
 spotify: https://open.spotify.com/playlist/6dE1FmktG68FTcUgHN1hN7?si=4af41eded4404374
 instagram: ninja.dance.az


### PR DESCRIPTION
Removes the `website: test.com` value left in `dj-bul.yaml` from a Keystatic test edit on June 26. The `website` field was added to the DJ schema as `z.string().url()`, so `test.com` (missing `https://`) fails URL validation and breaks the build.