### PR TITLE
fix: update stale Printful references to Printify

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The White Rabbit Society is the hub for West Coast Swing dancing in Arizona — connecting dancers to local events, instructors, venues, DJs, and community resources across Phoenix, Tucson, Prescott, and beyond.
 
-This repo is the source for [whiterabbitwcs.com](https://whiterabbitwcs.com): an Astro 5 static site deployed on Cloudflare Workers, with a Git-backed CMS, Google Calendar integration, and a Printful-connected merch shop.
+This repo is the source for [whiterabbitwcs.com](https://whiterabbitwcs.com): an Astro 5 static site deployed on Cloudflare Workers, with a Git-backed CMS, Google Calendar integration, and a Printify-connected merch shop.
 
 ---
 

--- a/src/pages/shop/success.astro
+++ b/src/pages/shop/success.astro
@@ -9,8 +9,8 @@ import Layout from '../../layouts/Layout.astro';
         <div class="result-icon">✓</div>
         <h1 class="result-title gradient-text">Order Confirmed</h1>
         <p class="result-text">
-          Your order is in. Printful will handle production and shipping — expect a
-          confirmation email shortly.
+          Your order is in. Printify will handle production and shipping — a
+          confirmation email is on its way.
         </p>
         <a href="/shop" class="btn">Back to Shop</a>
       </div>


### PR DESCRIPTION
## Summary
- Fixes leftover "Printful" copy on the shop success page and in the README, from before the migration to Printify fulfillment.

## Test plan
- [ ] Visually confirm `/shop/success` reads "Printify"