### PR TITLE
fix: send order-confirmation emails and add checkout/webhook logging

### DIFF
--- a/SHOP.md
+++ b/SHOP.md
@@ -7,9 +7,32 @@ Product data is fetched from Printify and committed to `src/data/products.json`.
 1. Customer selects product/variant → `/api/checkout` creates a Stripe Checkout session
 2. Stripe redirects to hosted checkout; on success, fires a webhook to `/api/stripe-webhook`
 3. Webhook calls `createPrintifyOrder` in `src/lib/printful.ts`, which creates a **draft** order in Printify
-4. Draft sits in the Printify dashboard for manual review — hit "Send to production" there to fulfill
+4. Webhook sends the customer an order-confirmation email via Resend (best-effort — failure is logged but doesn't fail the webhook or retry the Printify order)
+5. Draft sits in the Printify dashboard for manual review — hit "Send to production" there to fulfill
+
+Printify itself never emails the customer here — this is a custom API integration, not a connected storefront, so Printify only talks to the merchant account. All customer-facing email is this app's responsibility.
 
 Orders are intentionally left as drafts (the `send_to_production` API call is omitted) so each order can be reviewed before Printify charges for fulfillment.
+
+## Debugging
+
+`checkout.ts` and `stripe-webhook.ts` log to Cloudflare Workers Logs (`console.log`/`console.error`, viewable in the Cloudflare dashboard or `wrangler tail`). Webhook logs are prefixed `[stripe-webhook] [<stripe event id>]` so every line for one order can be grepped out together; checkout logs are prefixed `[checkout]` and include the Stripe session id, which correlates to the webhook logs for the same order.
+
+## Customer Order-Confirmation Email
+
+Sent from the webhook via [Resend](https://resend.com)'s HTTP API (`sendResendEmail` in `src/lib/email.ts`), gated behind a `RESEND_API_KEY` secret. Chosen over Cloudflare's own Email Service because Cloudflare requires a Workers Paid plan ($5/mo flat) just to send to arbitrary (non-pre-verified) recipients, whereas Resend's free tier — 3,000 emails/month, 100/day — costs $0 and comfortably covers this shop's volume.
+
+Setup (one-time, outside this repo):
+
+1. Sign up at resend.com (free)
+2. Add and verify the sending domain (`whiterabbitwcs.com`) — Resend walks you through the SPF/DKIM DNS records
+3. Create an API key, then `wrangler secret put RESEND_API_KEY`
+
+Until `RESEND_API_KEY` is set, `sendResendEmail()` falls back to a `console.log` stub — safe to deploy either way, but customers won't actually receive anything until Resend is configured.
+
+This is separate from the `SEND_EMAIL` binding used by the contact form, which stays on Cloudflare's own Email Routing since it only ever sends to the site's own inbox (free, no plan requirement, no domain onboarding needed — it was already working).
+
+Stripe's own automatic payment-receipt email (Dashboard → Settings → Customer emails → "Successful payments") is a separate, independent toggle and worth enabling too — it's the payment record, not a replacement for the order-confirmation email above.
 
 ## Payment Model
 
@@ -30,6 +53,7 @@ To update the Printify payment method: **printify.com → Wallet → Payments**.
 | `src/pages/api/checkout.ts` | Creates Stripe Checkout session |
 | `src/pages/api/stripe-webhook.ts` | Handles `checkout.session.completed`, creates Printify order |
 | `src/lib/printful.ts` | `createPrintifyOrder` — Printify API wrapper (filename is legacy) |
+| `src/lib/email.ts` | `sendResendEmail` (order confirmations, via Resend) and `sendEmail` (contact form, via Cloudflare `send_email` binding) |
 | `src/data/products.json` | Pre-fetched product catalog (committed; update via fetch script) |
 
 ## Refreshing Product Data

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,0 +1,68 @@
+export interface SendEmailOptions {
+  fromAddr: string;
+  fromName: string;
+  to: string;
+  subject: string;
+  text: string;
+}
+
+type SendEmailBinding = { send: (msg: unknown) => Promise<void> };
+
+/**
+ * Sends via a Cloudflare `send_email` binding. Falls back to a console.log
+ * stub when the binding isn't configured (e.g. local dev), matching the
+ * pattern already used by the contact form.
+ */
+export async function sendEmail(binding: SendEmailBinding | undefined, opts: SendEmailOptions): Promise<void> {
+  const { fromAddr, fromName, to, subject, text } = opts;
+
+  if (!binding) {
+    console.log(`[email] would send to ${to}\nSubject: ${subject}\n\n${text}`);
+    return;
+  }
+
+  const { createMimeMessage } = await import('mimetext');
+  const { EmailMessage } = await import('cloudflare:email');
+
+  const msg = createMimeMessage();
+  msg.setSender({ name: fromName, addr: fromAddr });
+  msg.setRecipient(to);
+  msg.setSubject(subject);
+  msg.addMessage({ contentType: 'text/plain', data: text });
+
+  const message = new EmailMessage(fromAddr, to, msg.asRaw());
+  await binding.send(message);
+}
+
+/**
+ * Sends via Resend's HTTP API — used for order-confirmation emails, which
+ * (unlike the contact form) need to reach arbitrary customer addresses.
+ * Falls back to a console.log stub when no API key is configured (e.g.
+ * local dev, or before Resend is set up).
+ */
+export async function sendResendEmail(apiKey: string | undefined, opts: SendEmailOptions): Promise<void> {
+  const { fromAddr, fromName, to, subject, text } = opts;
+
+  if (!apiKey) {
+    console.log(`[email] would send (via Resend) to ${to}\nSubject: ${subject}\n\n${text}`);
+    return;
+  }
+
+  const res = await fetch('https://api.resend.com/emails', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      from: `${fromName} <${fromAddr}>`,
+      to,
+      subject,
+      text,
+    }),
+  });
+
+  if (!res.ok) {
+    throw new Error(`Resend send failed: ${res.status} ${await res.text()}`);
+  }
+}

--- a/src/lib/printful.ts
+++ b/src/lib/printful.ts
@@ -30,6 +30,7 @@ export interface PrintifyOrderRecipient {
   email: string;
   phone: string;
   address1: string;
+  address2?: string;
   city: string;
   region: string;
   country: string;

--- a/src/lib/printful.ts
+++ b/src/lib/printful.ts
@@ -41,7 +41,7 @@ export async function createPrintifyOrder(
   shopId: string,
   recipient: PrintifyOrderRecipient,
   items: { productId: string; variantId: number; quantity: number; externalId?: string }[]
-): Promise<void> {
+): Promise<{ id: string }> {
   const externalId = items[0]?.externalId;
   const headers = {
     Authorization: `Bearer ${apiToken}`,
@@ -67,4 +67,6 @@ export async function createPrintifyOrder(
     const body = await createRes.text();
     throw new Error(`Printify order failed: ${createRes.status} ${body}`);
   }
+
+  return createRes.json();
 }

--- a/src/pages/api/checkout.ts
+++ b/src/pages/api/checkout.ts
@@ -19,11 +19,15 @@ export async function POST({ request, locals }: APIContext) {
   try {
     body = await request.json();
   } catch {
+    console.error('[checkout] Invalid JSON body');
     return new Response('Invalid JSON', { status: 400 });
   }
 
   const { productId, variantId, quantity = 1 } = body;
-  if (!productId || !variantId) return new Response('Missing required fields', { status: 400 });
+  if (!productId || !variantId) {
+    console.error('[checkout] Missing productId/variantId in request body');
+    return new Response('Missing required fields', { status: 400 });
+  }
 
   // Printify variant ids are scoped to the underlying blank (e.g. a Bella
   // Canvas blueprint), not to a specific design — the same variant id is
@@ -33,39 +37,50 @@ export async function POST({ request, locals }: APIContext) {
   const products = productsData as Product[];
   const product = products.find(p => p.id === productId);
   const variant = product?.variants.find(v => v.id === variantId);
-  if (!product || !variant) return new Response('Unknown product/variant', { status: 400 });
+  if (!product || !variant) {
+    console.error(`[checkout] Unknown productId=${productId} variantId=${variantId} (not found in products.json)`);
+    return new Response('Unknown product/variant', { status: 400 });
+  }
 
   const stripe = new Stripe(stripeKey);
 
-  const session = await stripe.checkout.sessions.create({
-    mode: 'payment',
-    line_items: [
-      {
-        quantity,
-        price_data: {
-          currency: 'usd',
-          unit_amount: Math.round(parseFloat(variant.price) * 100),
-          product_data: {
-            name: product.name,
-            description: variant.name,
+  let session: Stripe.Checkout.Session;
+  try {
+    session = await stripe.checkout.sessions.create({
+      mode: 'payment',
+      line_items: [
+        {
+          quantity,
+          price_data: {
+            currency: 'usd',
+            unit_amount: Math.round(parseFloat(variant.price) * 100),
+            product_data: {
+              name: product.name,
+              description: variant.name,
+            },
           },
         },
+      ],
+      shipping_address_collection: {
+        allowed_countries: ['US'],
       },
-    ],
-    shipping_address_collection: {
-      allowed_countries: ['US'],
-    },
-    phone_number_collection: {
-      enabled: true,
-    },
-    metadata: {
-      printify_product_id: product.id,
-      printify_variant_id: String(variantId),
-      quantity: String(quantity),
-    },
-    success_url: `${origin}/shop/success?session_id={CHECKOUT_SESSION_ID}`,
-    cancel_url: `${origin}/shop`,
-  });
+      phone_number_collection: {
+        enabled: true,
+      },
+      metadata: {
+        printify_product_id: product.id,
+        printify_variant_id: String(variantId),
+        quantity: String(quantity),
+      },
+      success_url: `${origin}/shop/success?session_id={CHECKOUT_SESSION_ID}`,
+      cancel_url: `${origin}/shop`,
+    });
+  } catch (err) {
+    console.error(`[checkout] Stripe session creation failed for productId=${product.id} variantId=${variantId}:`, err);
+    return new Response(`Stripe error: ${err}`, { status: 500 });
+  }
+
+  console.log(`[checkout] Created session ${session.id} for productId=${product.id} variantId=${variantId} quantity=${quantity}`);
 
   return new Response(JSON.stringify({ url: session.url }), {
     headers: { 'Content-Type': 'application/json' },

--- a/src/pages/api/contact.ts
+++ b/src/pages/api/contact.ts
@@ -1,6 +1,6 @@
 import type { APIContext } from "astro";
 import { env as cfEnv } from "cloudflare:workers";
-import { createMimeMessage } from "mimetext";
+import { sendEmail } from "../../lib/email";
 
 export const prerender = false;
 
@@ -23,23 +23,9 @@ const FROM_ADDR = "noreply@whiterabbitwcs.com";
 const FROM_NAME = "White Rabbit WCS";
 const TO = "whiterabbitwcs@gmail.com";
 
-async function sendEmail(
-  subject: string,
-  text: string
-): Promise<void> {
+async function sendContactEmail(subject: string, text: string): Promise<void> {
   const binding = (cfEnv as any).SEND_EMAIL as { send: (msg: unknown) => Promise<void> } | undefined;
-  if (!binding) {
-    console.log(`[contact] would send email\nSubject: ${subject}\n\n${text}`);
-    return;
-  }
-  const { EmailMessage } = await import("cloudflare:email");
-  const msg = createMimeMessage();
-  msg.setSender({ name: FROM_NAME, addr: FROM_ADDR });
-  msg.setRecipient(TO);
-  msg.setSubject(subject);
-  msg.addMessage({ contentType: "text/plain", data: text });
-  const message = new EmailMessage(FROM_ADDR, TO, msg.asRaw());
-  await binding.send(message);
+  await sendEmail(binding, { fromAddr: FROM_ADDR, fromName: FROM_NAME, to: TO, subject, text });
 }
 
 async function verifyTurnstile(token: string, secretKey: string): Promise<{ success: boolean; codes: string[] }> {
@@ -85,14 +71,14 @@ export async function POST({ request }: APIContext) {
   }
 
   if (type === "feedback") {
-    await sendEmail(
+    await sendContactEmail(
       `New feedback from ${name}`,
       [`Name: ${name}`, `Email: ${email}`, ``, `Message:`, message].join("\n")
     );
   }
 
   if (type === "discord") {
-    await sendEmail(
+    await sendContactEmail(
       `New Discord request from ${name}`,
       [
         `Name: ${name}`,

--- a/src/pages/api/stripe-webhook.ts
+++ b/src/pages/api/stripe-webhook.ts
@@ -2,8 +2,22 @@ import type { APIContext } from 'astro';
 import Stripe from 'stripe';
 import { env as cfEnv } from 'cloudflare:workers';
 import { createPrintifyOrder } from '../../lib/printful';
+import { sendResendEmail } from '../../lib/email';
+import productsData from '../../data/products.json';
 
 export const prerender = false;
+
+const ORDER_FROM_ADDR = 'orders@whiterabbitwcs.com';
+const ORDER_FROM_NAME = 'White Rabbit WCS';
+
+// Every log line is prefixed with this and the Stripe event id so a single
+// order can be grepped out of Cloudflare's aggregate Worker logs.
+function log(eventId: string | undefined, msg: string) {
+  console.log(`[stripe-webhook]${eventId ? ` [${eventId}]` : ''} ${msg}`);
+}
+function logError(eventId: string | undefined, msg: string, err?: unknown) {
+  console.error(`[stripe-webhook]${eventId ? ` [${eventId}]` : ''} ${msg}`, err ?? '');
+}
 
 export async function POST({ request, locals }: APIContext) {
   const env = (locals as { runtime?: { env?: Record<string, string> } }).runtime?.env ?? {};
@@ -13,13 +27,23 @@ export async function POST({ request, locals }: APIContext) {
   const printifyToken = env.PRINTIFY_API_TOKEN;
   const printifyShopId = env.PRINTIFY_SHOP_ID;
   const kv = (cfEnv as unknown as Env).SESSION;
+  const resendApiKey = env.RESEND_API_KEY;
 
   if (!stripeKey || !webhookSecret || !printifyToken || !printifyShopId) {
+    logError(undefined, `Missing env vars: ${[
+      !stripeKey && 'STRIPE_SECRET_KEY',
+      !webhookSecret && 'STRIPE_WEBHOOK_SECRET',
+      !printifyToken && 'PRINTIFY_API_TOKEN',
+      !printifyShopId && 'PRINTIFY_SHOP_ID',
+    ].filter(Boolean).join(', ')}`);
     return new Response('Missing env vars', { status: 500 });
   }
 
   const sig = request.headers.get('stripe-signature');
-  if (!sig) return new Response('No signature', { status: 400 });
+  if (!sig) {
+    logError(undefined, 'Request had no stripe-signature header');
+    return new Response('No signature', { status: 400 });
+  }
 
   const rawBody = await request.text();
   const stripe = new Stripe(stripeKey);
@@ -28,8 +52,11 @@ export async function POST({ request, locals }: APIContext) {
   try {
     event = await stripe.webhooks.constructEventAsync(rawBody, sig, webhookSecret);
   } catch (err) {
+    logError(undefined, 'Signature verification failed', err);
     return new Response(`Webhook signature failed: ${err}`, { status: 400 });
   }
+
+  log(event.id, `Received event type=${event.type}`);
 
   if (event.type !== 'checkout.session.completed') {
     return new Response('OK', { status: 200 });
@@ -40,9 +67,11 @@ export async function POST({ request, locals }: APIContext) {
   if (kv) {
     const already = await kv.get(idempotencyKey);
     if (already) {
-      console.log(`[stripe-webhook] Duplicate event ${event.id}, skipping`);
+      log(event.id, `Duplicate event, already processed as session ${already}, skipping`);
       return new Response('OK', { status: 200 });
     }
+  } else {
+    logError(event.id, 'SESSION KV binding unavailable — idempotency check skipped, duplicate orders are possible');
   }
 
   const session = event.data.object as Stripe.Checkout.Session;
@@ -50,29 +79,33 @@ export async function POST({ request, locals }: APIContext) {
   const variantId = Number(session.metadata?.printify_variant_id);
   const quantity = Number(session.metadata?.quantity ?? 1);
 
+  log(event.id, `session=${session.id} productId=${productId} variantId=${variantId} quantity=${quantity}`);
+
   if (!productId || !variantId) {
-    console.error('[stripe-webhook] Missing printify metadata in session');
+    logError(event.id, `Missing printify metadata on session ${session.id}: ${JSON.stringify(session.metadata)}`);
     return new Response('Missing variant', { status: 400 });
   }
 
   const shipping = session.collected_information?.shipping_details;
   if (!shipping?.address) {
-    console.error('[stripe-webhook] No shipping address on session');
+    logError(event.id, `No shipping address on session ${session.id}`);
     return new Response('No shipping address', { status: 400 });
   }
 
   const nameParts = (shipping.name ?? session.customer_details?.name ?? 'Customer').split(' ');
   const firstName = nameParts[0];
   const lastName = nameParts.slice(1).join(' ') || '-';
+  const customerEmail = session.customer_details?.email ?? '';
 
+  let printifyOrder: { id: string };
   try {
-    await createPrintifyOrder(
+    printifyOrder = await createPrintifyOrder(
       printifyToken,
       printifyShopId,
       {
         first_name: firstName,
         last_name: lastName,
-        email: session.customer_details?.email ?? '',
+        email: customerEmail,
         phone: session.customer_details?.phone ?? '0000000000',
         address1: shipping.address.line1 ?? '',
         city: shipping.address.city ?? '',
@@ -83,7 +116,7 @@ export async function POST({ request, locals }: APIContext) {
       [{ productId, variantId, quantity, externalId: session.id }]
     );
   } catch (err) {
-    console.error('[stripe-webhook] Printify order failed:', err);
+    logError(event.id, `Printify order creation failed for session ${session.id}`, err);
     return new Response(`Printify error: ${err}`, { status: 500 });
   }
 
@@ -92,6 +125,44 @@ export async function POST({ request, locals }: APIContext) {
     await kv.put(idempotencyKey, session.id, { expirationTtl: 604800 });
   }
 
-  console.log(`[stripe-webhook] Printify order created for session ${session.id}`);
+  log(event.id, `Printify draft order ${printifyOrder.id} created for session ${session.id}`);
+
+  // Best-effort: an email failure shouldn't turn into a duplicate Printify
+  // order on Stripe's retry, so this never affects the response status.
+  if (customerEmail) {
+    try {
+      const products = productsData as { id: string; name: string; variants: { id: number; name: string }[] }[];
+      const product = products.find(p => p.id === productId);
+      const variant = product?.variants.find(v => v.id === variantId);
+      const itemLine = product ? `${quantity} x ${product.name}${variant ? ` (${variant.name})` : ''}` : 'your item';
+
+      await sendResendEmail(resendApiKey, {
+        fromAddr: ORDER_FROM_ADDR,
+        fromName: ORDER_FROM_NAME,
+        to: customerEmail,
+        subject: 'Your White Rabbit order is confirmed',
+        text: [
+          `Thanks, ${firstName}! Your order is confirmed.`,
+          ``,
+          itemLine,
+          ``,
+          `Shipping to:`,
+          shipping.name ?? '',
+          shipping.address.line1 ?? '',
+          [shipping.address.city, shipping.address.state, shipping.address.postal_code].filter(Boolean).join(', '),
+          ``,
+          `Printify will handle production and shipping — you'll get a shipping notification once it's on its way.`,
+          ``,
+          `Order reference: ${session.id}`,
+        ].join('\n'),
+      });
+      log(event.id, `Order confirmation email sent to ${customerEmail}`);
+    } catch (err) {
+      logError(event.id, `Order confirmation email failed for session ${session.id}`, err);
+    }
+  } else {
+    logError(event.id, `No customer email on session ${session.id} — confirmation email skipped`);
+  }
+
   return new Response('OK', { status: 200 });
 }

--- a/src/pages/api/stripe-webhook.ts
+++ b/src/pages/api/stripe-webhook.ts
@@ -108,6 +108,7 @@ export async function POST({ request, locals }: APIContext) {
         email: customerEmail,
         phone: session.customer_details?.phone ?? '0000000000',
         address1: shipping.address.line1 ?? '',
+        ...(shipping.address.line2 ? { address2: shipping.address.line2 } : {}),
         city: shipping.address.city ?? '',
         region: shipping.address.state ?? '',
         country: shipping.address.country ?? 'US',
@@ -135,6 +136,12 @@ export async function POST({ request, locals }: APIContext) {
       const product = products.find(p => p.id === productId);
       const variant = product?.variants.find(v => v.id === variantId);
       const itemLine = product ? `${quantity} x ${product.name}${variant ? ` (${variant.name})` : ''}` : 'your item';
+      const addressLines = [
+        shipping.name,
+        shipping.address.line1,
+        shipping.address.line2,
+        [shipping.address.city, shipping.address.state, shipping.address.postal_code].filter(Boolean).join(', '),
+      ].filter(Boolean);
 
       await sendResendEmail(resendApiKey, {
         fromAddr: ORDER_FROM_ADDR,
@@ -147,9 +154,7 @@ export async function POST({ request, locals }: APIContext) {
           itemLine,
           ``,
           `Shipping to:`,
-          shipping.name ?? '',
-          shipping.address.line1 ?? '',
-          [shipping.address.city, shipping.address.state, shipping.address.postal_code].filter(Boolean).join(', '),
+          ...addressLines,
           ``,
           `Printify will handle production and shipping — you'll get a shipping notification once it's on its way.`,
           ``,


### PR DESCRIPTION
## Summary
- Customers were never receiving an order-confirmation email — nothing in the codebase sent one, despite the shop success page promising it. Adds a Resend-based confirmation email sent from the Stripe webhook after the Printify draft order is created.
- Adds correlation-friendly logging across `checkout.ts` and `stripe-webhook.ts` (Stripe event id / session id prefixes) so a specific order can be traced through Cloudflare Workers Logs.
- `createPrintifyOrder` now returns the Printify order id so it can be logged.

## Setup required before emails actually send
1. Sign up at resend.com (free tier: 3,000 emails/mo, 100/day)
2. Verify the sending domain (`whiterabbitwcs.com`) via the DNS records Resend provides
3. `wrangler secret put RESEND_API_KEY`

Until that's done, the email send safely falls back to a `console.log` stub — no crash, just no email. Order creation in Printify is unaffected either way.

## Test plan
- [ ] Place a test order, confirm Printify draft order still gets created
- [ ] Check Cloudflare Workers Logs for `[checkout]` and `[stripe-webhook] [<event id>]` lines
- [ ] After setting `RESEND_API_KEY`, confirm the customer receives the confirmation email