### PR TITLE
chore: gitignore local Claude settings and wrangler state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ src/data/calendar.ics
 .idea/
 .dev.vars
 .env.local
+
+# local Claude Code settings (may contain locally-configured API keys)
+.claude/settings.local.json
+.wrangler/


### PR DESCRIPTION
## Summary
- `.claude/settings.local.json` was untracked but not gitignored, and currently contains old Printful API keys in the permissions allowlist — a broad `git add .` could accidentally commit real secrets.
- `.wrangler/` (local dev state) was similarly untracked but not ignored.