### PR TITLE
fix: resolve checkout product by id, not by variant id alone

### DIFF
--- a/src/pages/api/checkout.ts
+++ b/src/pages/api/checkout.ts
@@ -15,20 +15,25 @@ export async function POST({ request, locals }: APIContext) {
 
   const origin = request.headers.get('origin') ?? 'http://localhost:4321';
 
-  let body: { variantId: number; quantity?: number };
+  let body: { productId: string; variantId: number; quantity?: number };
   try {
     body = await request.json();
   } catch {
     return new Response('Invalid JSON', { status: 400 });
   }
 
-  const { variantId, quantity = 1 } = body;
-  if (!variantId) return new Response('Missing required fields', { status: 400 });
+  const { productId, variantId, quantity = 1 } = body;
+  if (!productId || !variantId) return new Response('Missing required fields', { status: 400 });
 
+  // Printify variant ids are scoped to the underlying blank (e.g. a Bella
+  // Canvas blueprint), not to a specific design — the same variant id is
+  // reused across every product built on that blank. Resolving by variant
+  // id alone can silently match the wrong product, so productId must be
+  // used to pin down which product first.
   const products = productsData as Product[];
-  const product = products.find(p => p.variants.some(v => v.id === variantId));
+  const product = products.find(p => p.id === productId);
   const variant = product?.variants.find(v => v.id === variantId);
-  if (!product || !variant) return new Response('Unknown variant', { status: 400 });
+  if (!product || !variant) return new Response('Unknown product/variant', { status: 400 });
 
   const stripe = new Stripe(stripeKey);
 

--- a/src/pages/shop.astro
+++ b/src/pages/shop.astro
@@ -297,6 +297,7 @@ const schema = [
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
+          productId: currentProduct.id,
           variantId: variant.id,
           quantity: 1,
         }),


### PR DESCRIPTION
## Summary
- **Bug**: at least one customer received the wrong shirt design. Root cause: Printify variant ids are scoped to the underlying blank (e.g. Bella Canvas 3001), not to a specific design — 264 of 561 variant ids in `products.json` are shared across 2-13 different designs that use the same blank.
- `checkout.ts` resolved the product with `products.find(p => p.variants.some(v => v.id === variantId))`, which matches on variant id alone and silently picks whichever product happens to come first in the array — not necessarily the one the customer selected.
- Fix: the shop page now sends `productId` alongside `variantId`, and checkout resolves the product by id directly instead of inferring it from a non-unique variant id.

## Test plan
- [ ] On `/shop`, open several designs that share a blank/size/color (e.g. any two Nivens tees), buy each, and confirm the Stripe session `metadata.printify_product_id` matches the design actually opened
- [ ] Confirm existing single-design purchases still work