### PR TITLE
feat: notify the merchant inbox when a new order comes in

### DIFF
--- a/SHOP.md
+++ b/SHOP.md
@@ -7,7 +7,7 @@ Product data is fetched from Printify and committed to `src/data/products.json`.
 1. Customer selects product/variant → `/api/checkout` creates a Stripe Checkout session
 2. Stripe redirects to hosted checkout; on success, fires a webhook to `/api/stripe-webhook`
 3. Webhook calls `createPrintifyOrder` in `src/lib/printful.ts`, which creates a **draft** order in Printify
-4. Webhook sends the customer an order-confirmation email via Resend (best-effort — failure is logged but doesn't fail the webhook or retry the Printify order)
+4. Webhook sends the customer an order-confirmation email via Resend, and a new-order notification to `whiterabbitwcs@gmail.com` (both best-effort — failure is logged but doesn't fail the webhook or retry the Printify order)
 5. Draft sits in the Printify dashboard for manual review — hit "Send to production" there to fulfill
 
 Printify itself never emails the customer here — this is a custom API integration, not a connected storefront, so Printify only talks to the merchant account. All customer-facing email is this app's responsibility.
@@ -27,6 +27,10 @@ Setup (one-time, outside this repo):
 1. Sign up at resend.com (free)
 2. Add and verify the sending domain (`whiterabbitwcs.com`) — Resend walks you through the SPF/DKIM DNS records
 3. Create an API key, then `wrangler secret put RESEND_API_KEY`
+
+## Merchant New-Order Notification
+
+Sent to `whiterabbitwcs@gmail.com` via the same `SEND_EMAIL` Cloudflare binding the contact form uses (`sendEmail` in `src/lib/email.ts`) — no separate setup needed, it's already configured. If order volume ever makes this noisy, filter it on the Gmail side rather than touching the code (the sender is `orders@whiterabbitwcs.com`).
 
 Until `RESEND_API_KEY` is set, `sendResendEmail()` falls back to a `console.log` stub — safe to deploy either way, but customers won't actually receive anything until Resend is configured.
 

--- a/src/pages/api/stripe-webhook.ts
+++ b/src/pages/api/stripe-webhook.ts
@@ -2,13 +2,14 @@ import type { APIContext } from 'astro';
 import Stripe from 'stripe';
 import { env as cfEnv } from 'cloudflare:workers';
 import { createPrintifyOrder } from '../../lib/printful';
-import { sendResendEmail } from '../../lib/email';
+import { sendEmail, sendResendEmail } from '../../lib/email';
 import productsData from '../../data/products.json';
 
 export const prerender = false;
 
 const ORDER_FROM_ADDR = 'orders@whiterabbitwcs.com';
 const ORDER_FROM_NAME = 'White Rabbit WCS';
+const MERCHANT_TO = 'whiterabbitwcs@gmail.com';
 
 // Every log line is prefixed with this and the Stripe event id so a single
 // order can be grepped out of Cloudflare's aggregate Worker logs.
@@ -28,6 +29,7 @@ export async function POST({ request, locals }: APIContext) {
   const printifyShopId = env.PRINTIFY_SHOP_ID;
   const kv = (cfEnv as unknown as Env).SESSION;
   const resendApiKey = env.RESEND_API_KEY;
+  const merchantEmailBinding = (cfEnv as any).SEND_EMAIL as { send: (msg: unknown) => Promise<void> } | undefined;
 
   if (!stripeKey || !webhookSecret || !printifyToken || !printifyShopId) {
     logError(undefined, `Missing env vars: ${[
@@ -128,21 +130,21 @@ export async function POST({ request, locals }: APIContext) {
 
   log(event.id, `Printify draft order ${printifyOrder.id} created for session ${session.id}`);
 
+  const products = productsData as { id: string; name: string; variants: { id: number; name: string }[] }[];
+  const product = products.find(p => p.id === productId);
+  const variant = product?.variants.find(v => v.id === variantId);
+  const itemLine = product ? `${quantity} x ${product.name}${variant ? ` (${variant.name})` : ''}` : 'your item';
+  const addressLines = [
+    shipping.name,
+    shipping.address.line1,
+    shipping.address.line2,
+    [shipping.address.city, shipping.address.state, shipping.address.postal_code].filter(Boolean).join(', '),
+  ].filter(Boolean);
+
   // Best-effort: an email failure shouldn't turn into a duplicate Printify
-  // order on Stripe's retry, so this never affects the response status.
+  // order on Stripe's retry, so neither of these ever affects the response status.
   if (customerEmail) {
     try {
-      const products = productsData as { id: string; name: string; variants: { id: number; name: string }[] }[];
-      const product = products.find(p => p.id === productId);
-      const variant = product?.variants.find(v => v.id === variantId);
-      const itemLine = product ? `${quantity} x ${product.name}${variant ? ` (${variant.name})` : ''}` : 'your item';
-      const addressLines = [
-        shipping.name,
-        shipping.address.line1,
-        shipping.address.line2,
-        [shipping.address.city, shipping.address.state, shipping.address.postal_code].filter(Boolean).join(', '),
-      ].filter(Boolean);
-
       await sendResendEmail(resendApiKey, {
         fromAddr: ORDER_FROM_ADDR,
         fromName: ORDER_FROM_NAME,
@@ -167,6 +169,29 @@ export async function POST({ request, locals }: APIContext) {
     }
   } else {
     logError(event.id, `No customer email on session ${session.id} — confirmation email skipped`);
+  }
+
+  try {
+    await sendEmail(merchantEmailBinding, {
+      fromAddr: ORDER_FROM_ADDR,
+      fromName: ORDER_FROM_NAME,
+      to: MERCHANT_TO,
+      subject: `New order: ${itemLine}`,
+      text: [
+        itemLine,
+        ``,
+        `Customer: ${shipping.name ?? session.customer_details?.name ?? 'Unknown'}${customerEmail ? ` <${customerEmail}>` : ''}`,
+        ``,
+        `Shipping to:`,
+        ...addressLines,
+        ``,
+        `Printify draft order: ${printifyOrder.id} (review and send to production at printify.com)`,
+        `Stripe session: ${session.id}`,
+      ].join('\n'),
+    });
+    log(event.id, `Merchant notification sent for session ${session.id}`);
+  } catch (err) {
+    logError(event.id, `Merchant notification failed for session ${session.id}`, err);
   }
 
   return new Response('OK', { status: 200 });

--- a/src/pages/api/stripe-webhook.ts
+++ b/src/pages/api/stripe-webhook.ts
@@ -172,6 +172,13 @@ export async function POST({ request, locals }: APIContext) {
   }
 
   try {
+    // Stripe's dashboard search accepts any object id directly; there's no
+    // confirmed direct deep-link for a specific Printify order, so that one
+    // links to the general orders list instead (search there by the id below).
+    const stripeDashboardBase = stripeKey.startsWith('sk_test_')
+      ? 'https://dashboard.stripe.com/test/search?query='
+      : 'https://dashboard.stripe.com/search?query=';
+
     await sendEmail(merchantEmailBinding, {
       fromAddr: ORDER_FROM_ADDR,
       fromName: ORDER_FROM_NAME,
@@ -185,8 +192,8 @@ export async function POST({ request, locals }: APIContext) {
         `Shipping to:`,
         ...addressLines,
         ``,
-        `Printify draft order: ${printifyOrder.id} (review and send to production at printify.com)`,
-        `Stripe session: ${session.id}`,
+        `Printify draft order: ${printifyOrder.id} — review and send to production at https://printify.com/app/orders (search for this order id)`,
+        `Stripe: ${stripeDashboardBase}${encodeURIComponent(session.id)}`,
       ].join('\n'),
     });
     log(event.id, `Merchant notification sent for session ${session.id}`);


### PR DESCRIPTION
## Summary
- Only the customer got an email on order completion — no way to know a new order landed short of manually checking Printify.
- Adds a second, best-effort email to `whiterabbitwcs@gmail.com` via the existing `SEND_EMAIL` Cloudflare binding (same one the contact form already uses), so no new setup/secrets needed.
- Includes item, customer contact, shipping address, and the Printify draft order id for quick review.

## Test plan
- [ ] Place a test order, confirm both the customer confirmation and the merchant notification land