### PR TITLE
fix: harden checkout against redirect abuse, spam, and error leaks

### DIFF
--- a/SHOP.md
+++ b/SHOP.md
@@ -14,6 +14,12 @@ Printify itself never emails the customer here — this is a custom API integrat
 
 Orders are intentionally left as drafts (the `send_to_production` API call is omitted) so each order can be reviewed before Printify charges for fulfillment.
 
+## Security
+
+- `success_url`/`cancel_url` use a hardcoded `SITE_ORIGIN` (the deployed site's own URL) rather than the client-supplied `Origin` header. That header is trivially spoofable and, unvalidated, would let anyone redirect a paying customer to an arbitrary domain after a real Stripe payment completes.
+- `/api/checkout` requires a Cloudflare Turnstile token, same as the contact form (`verifyTurnstile` in `src/lib/turnstile.ts`), gated behind `TURNSTILE_SECRET_KEY`. Without it the endpoint could be scripted to generate unlimited Stripe Checkout sessions.
+- Both `checkout.ts` and `stripe-webhook.ts` log the real error server-side but return a generic message to the caller — never leak exception text in the HTTP response.
+
 ## Debugging
 
 `checkout.ts` and `stripe-webhook.ts` log to Cloudflare Workers Logs (`console.log`/`console.error`, viewable in the Cloudflare dashboard or `wrangler tail`). Webhook logs are prefixed `[stripe-webhook] [<stripe event id>]` so every line for one order can be grepped out together; checkout logs are prefixed `[checkout]` and include the Stripe session id, which correlates to the webhook logs for the same order.

--- a/SHOP.md
+++ b/SHOP.md
@@ -17,8 +17,8 @@ Orders are intentionally left as drafts (the `send_to_production` API call is om
 ## Security
 
 - `success_url`/`cancel_url` use a hardcoded `SITE_ORIGIN` (the deployed site's own URL) rather than the client-supplied `Origin` header. That header is trivially spoofable and, unvalidated, would let anyone redirect a paying customer to an arbitrary domain after a real Stripe payment completes.
-- `/api/checkout` requires a Cloudflare Turnstile token, same as the contact form (`verifyTurnstile` in `src/lib/turnstile.ts`), gated behind `TURNSTILE_SECRET_KEY`. Without it the endpoint could be scripted to generate unlimited Stripe Checkout sessions.
-- Both `checkout.ts` and `stripe-webhook.ts` log the real error server-side but return a generic message to the caller — never leak exception text in the HTTP response.
+- `/api/checkout` requires a Cloudflare Turnstile token, same as the contact form (`verifyTurnstile` in `src/lib/turnstile.ts`), gated behind `TURNSTILE_SECRET_KEY`. Without it the endpoint could be scripted to generate unlimited Stripe Checkout sessions. If that secret is ever missing in production, `checkout.ts` logs an error immediately rather than silently running with no abuse protection.
+- `checkout.ts` logs the real error server-side but returns a generic message to the browser for customer-facing failures — never leak exception text to a customer. `stripe-webhook.ts` is more targeted: the signature-check failure response is reachable by anyone (bots/scanners hit public webhook URLs constantly, and a bad signature usually means the caller isn't really Stripe), so that one stays generic. The Printify-order-creation failure response only fires *after* a verified Stripe signature, so its only audience is Stripe's own retry logic and your webhook dashboard — that one keeps the real error detail, since there's no attacker to withhold it from and it's genuinely useful for debugging from the Stripe side.
 
 ## Debugging
 

--- a/src/lib/turnstile.ts
+++ b/src/lib/turnstile.ts
@@ -1,0 +1,9 @@
+export async function verifyTurnstile(token: string, secretKey: string): Promise<{ success: boolean; codes: string[] }> {
+  const res = await fetch('https://challenges.cloudflare.com/turnstile/v0/siteverify', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ secret: secretKey, response: token }),
+  });
+  const data = (await res.json()) as { success: boolean; 'error-codes': string[] };
+  return { success: data.success, codes: data['error-codes'] ?? [] };
+}

--- a/src/pages/api/checkout.ts
+++ b/src/pages/api/checkout.ts
@@ -41,6 +41,11 @@ export async function POST({ request, locals }: APIContext) {
       console.error(`[checkout] Turnstile verification failed: ${codes.join(', ')}`);
       return new Response('Verification failed. Please try again.', { status: 400 });
     }
+  } else if (!import.meta.env.DEV) {
+    // Not fatal -- checkout still works -- but silently running with no
+    // abuse protection in production is worth knowing about immediately
+    // rather than discovering it later via a spam/fraud spike.
+    console.error('[checkout] TURNSTILE_SECRET_KEY not configured -- abuse protection is disabled');
   }
 
   // Printify variant ids are scoped to the underlying blank (e.g. a Bella

--- a/src/pages/api/checkout.ts
+++ b/src/pages/api/checkout.ts
@@ -1,11 +1,18 @@
 import type { APIContext } from 'astro';
 import Stripe from 'stripe';
 import productsData from '../../data/products.json';
+import { verifyTurnstile } from '../../lib/turnstile';
 
 type Variant = { id: number; name: string; price: string };
 type Product = { id: string; name: string; variants: Variant[] };
 
 export const prerender = false;
+
+// Falls back to the deployed site's canonical origin rather than trusting
+// the client-supplied Origin header, which is trivially spoofable (e.g.
+// via curl) and would otherwise let an attacker redirect a paying customer
+// to an arbitrary domain after a real Stripe payment completes.
+const SITE_ORIGIN = import.meta.env.DEV ? 'http://localhost:4321' : import.meta.env.SITE;
 
 export async function POST({ request, locals }: APIContext) {
   const env = (locals as { runtime?: { env?: Record<string, string> } }).runtime?.env ?? {};
@@ -13,9 +20,7 @@ export async function POST({ request, locals }: APIContext) {
   const stripeKey = env.STRIPE_SECRET_KEY;
   if (!stripeKey) return new Response('Stripe not configured', { status: 500 });
 
-  const origin = request.headers.get('origin') ?? 'http://localhost:4321';
-
-  let body: { productId: string; variantId: number; quantity?: number };
+  let body: { productId: string; variantId: number; quantity?: number; turnstileToken?: string };
   try {
     body = await request.json();
   } catch {
@@ -23,10 +28,19 @@ export async function POST({ request, locals }: APIContext) {
     return new Response('Invalid JSON', { status: 400 });
   }
 
-  const { productId, variantId, quantity = 1 } = body;
+  const { productId, variantId, quantity = 1, turnstileToken } = body;
   if (!productId || !variantId) {
     console.error('[checkout] Missing productId/variantId in request body');
     return new Response('Missing required fields', { status: 400 });
+  }
+
+  const turnstileSecret = env.TURNSTILE_SECRET_KEY;
+  if (turnstileSecret) {
+    const { success, codes } = await verifyTurnstile(turnstileToken ?? '', turnstileSecret);
+    if (!success) {
+      console.error(`[checkout] Turnstile verification failed: ${codes.join(', ')}`);
+      return new Response('Verification failed. Please try again.', { status: 400 });
+    }
   }
 
   // Printify variant ids are scoped to the underlying blank (e.g. a Bella
@@ -72,12 +86,12 @@ export async function POST({ request, locals }: APIContext) {
         printify_variant_id: String(variantId),
         quantity: String(quantity),
       },
-      success_url: `${origin}/shop/success?session_id={CHECKOUT_SESSION_ID}`,
-      cancel_url: `${origin}/shop`,
+      success_url: `${SITE_ORIGIN}/shop/success?session_id={CHECKOUT_SESSION_ID}`,
+      cancel_url: `${SITE_ORIGIN}/shop`,
     });
   } catch (err) {
     console.error(`[checkout] Stripe session creation failed for productId=${product.id} variantId=${variantId}:`, err);
-    return new Response(`Stripe error: ${err}`, { status: 500 });
+    return new Response('Something went wrong. Please try again.', { status: 500 });
   }
 
   console.log(`[checkout] Created session ${session.id} for productId=${product.id} variantId=${variantId} quantity=${quantity}`);

--- a/src/pages/api/contact.ts
+++ b/src/pages/api/contact.ts
@@ -1,6 +1,7 @@
 import type { APIContext } from "astro";
 import { env as cfEnv } from "cloudflare:workers";
 import { sendEmail } from "../../lib/email";
+import { verifyTurnstile } from "../../lib/turnstile";
 
 export const prerender = false;
 
@@ -26,16 +27,6 @@ const TO = "whiterabbitwcs@gmail.com";
 async function sendContactEmail(subject: string, text: string): Promise<void> {
   const binding = (cfEnv as any).SEND_EMAIL as { send: (msg: unknown) => Promise<void> } | undefined;
   await sendEmail(binding, { fromAddr: FROM_ADDR, fromName: FROM_NAME, to: TO, subject, text });
-}
-
-async function verifyTurnstile(token: string, secretKey: string): Promise<{ success: boolean; codes: string[] }> {
-  const res = await fetch("https://challenges.cloudflare.com/turnstile/v0/siteverify", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ secret: secretKey, response: token }),
-  });
-  const data = (await res.json()) as { success: boolean; "error-codes": string[] };
-  return { success: data.success, codes: data["error-codes"] ?? [] };
 }
 
 export async function POST({ request }: APIContext) {

--- a/src/pages/api/stripe-webhook.ts
+++ b/src/pages/api/stripe-webhook.ts
@@ -120,7 +120,11 @@ export async function POST({ request, locals }: APIContext) {
     );
   } catch (err) {
     logError(event.id, `Printify order creation failed for session ${session.id}`, err);
-    return new Response('Order processing failed', { status: 500 });
+    // Unlike the signature-check failure above, this path only runs after a
+    // verified Stripe signature -- the only caller who ever sees this
+    // response is Stripe's own retry logic and your webhook dashboard, so
+    // there's no attacker audience to withhold detail from here.
+    return new Response(`Printify error: ${err}`, { status: 500 });
   }
 
   // Mark this event as processed (7-day TTL covers Stripe's full retry window)

--- a/src/pages/api/stripe-webhook.ts
+++ b/src/pages/api/stripe-webhook.ts
@@ -55,7 +55,7 @@ export async function POST({ request, locals }: APIContext) {
     event = await stripe.webhooks.constructEventAsync(rawBody, sig, webhookSecret);
   } catch (err) {
     logError(undefined, 'Signature verification failed', err);
-    return new Response(`Webhook signature failed: ${err}`, { status: 400 });
+    return new Response('Invalid request', { status: 400 });
   }
 
   log(event.id, `Received event type=${event.type}`);
@@ -120,7 +120,7 @@ export async function POST({ request, locals }: APIContext) {
     );
   } catch (err) {
     logError(event.id, `Printify order creation failed for session ${session.id}`, err);
-    return new Response(`Printify error: ${err}`, { status: 500 });
+    return new Response('Order processing failed', { status: 500 });
   }
 
   // Mark this event as processed (7-day TTL covers Stripe's full retry window)

--- a/src/pages/shop.astro
+++ b/src/pages/shop.astro
@@ -131,6 +131,12 @@ const siteKey = "0x4AAAAAAC-SjNYO1rM3LezP";
 <script>
   import type { Product, ProductVariant, ProductImage } from '../lib/printful';
 
+  declare global {
+    interface Window {
+      turnstile?: { reset: (widget?: string | HTMLElement) => void };
+    }
+  }
+
   const dialog = document.getElementById('product-dialog') as HTMLDialogElement;
   const dialogClose = document.getElementById('dialog-close');
   const dialogImage = document.getElementById('dialog-image') as HTMLImageElement;
@@ -144,6 +150,20 @@ const siteKey = "0x4AAAAAAC-SjNYO1rM3LezP";
   const sizeGroup = document.getElementById('size-group') as HTMLElement;
   const btnStripe = document.getElementById('btn-stripe') as HTMLButtonElement;
   const dialogError = document.getElementById('dialog-error') as HTMLElement;
+  const turnstileWidget = document.querySelector('.cf-turnstile');
+
+  // If Turnstile's script never loads (ad blocker, privacy extension,
+  // network block on challenges.cloudflare.com), the widget silently never
+  // resolves and the button-click check below would repeat the same "please
+  // wait" message forever. After a grace period, swap to a message that
+  // actually explains what might be wrong.
+  let turnstileTimedOut = false;
+  if (turnstileWidget) {
+    setTimeout(() => {
+      const input = document.querySelector<HTMLInputElement>('[name=cf-turnstile-response]');
+      if (!input?.value) turnstileTimedOut = true;
+    }, 8000);
+  }
 
   let currentProduct: Product | null = null;
   let selectedColor = '';
@@ -290,22 +310,17 @@ const siteKey = "0x4AAAAAAC-SjNYO1rM3LezP";
     document.documentElement.style.overflow = "";
   });
 
-  declare global {
-    interface Window {
-      turnstile?: { reset: (widget?: string | HTMLElement) => void };
-    }
-  }
-
   btnStripe?.addEventListener('click', async () => {
     const variant = getVariant();
     if (!variant || !currentProduct) return;
 
-    const turnstileWidget = document.querySelector('.cf-turnstile');
     const turnstileInput = document.querySelector<HTMLInputElement>('[name=cf-turnstile-response]');
     const turnstileToken = turnstileInput?.value ?? '';
 
     if (turnstileWidget && !turnstileToken) {
-      dialogError.textContent = 'Please wait for the security check to complete.';
+      dialogError.textContent = turnstileTimedOut
+        ? "Security check couldn't load. If you're using an ad blocker or privacy extension, try disabling it for this site, then reload the page."
+        : 'Please wait for the security check to complete.';
       return;
     }
 

--- a/src/pages/shop.astro
+++ b/src/pages/shop.astro
@@ -12,6 +12,8 @@ const schema = [
     { name: "Shop", url: "https://whiterabbitwcs.com/shop" },
   ]),
 ];
+
+const siteKey = "0x4AAAAAAC-SjNYO1rM3LezP";
 ---
 
 <Layout
@@ -111,6 +113,7 @@ const schema = [
           <div class="dialog-price" id="dialog-price"></div>
 
           <div class="dialog-actions">
+            {siteKey && <div class="cf-turnstile" data-sitekey={siteKey} data-theme="dark"></div>}
             <button class="btn-buy" id="btn-stripe">
               Buy Now
             </button>
@@ -122,6 +125,8 @@ const schema = [
     </div>
   </dialog>
 </Layout>
+
+{siteKey && <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>}
 
 <script>
   import type { Product, ProductVariant, ProductImage } from '../lib/printful';
@@ -285,12 +290,28 @@ const schema = [
     document.documentElement.style.overflow = "";
   });
 
+  declare global {
+    interface Window {
+      turnstile?: { reset: (widget?: string | HTMLElement) => void };
+    }
+  }
+
   btnStripe?.addEventListener('click', async () => {
     const variant = getVariant();
     if (!variant || !currentProduct) return;
 
+    const turnstileWidget = document.querySelector('.cf-turnstile');
+    const turnstileInput = document.querySelector<HTMLInputElement>('[name=cf-turnstile-response]');
+    const turnstileToken = turnstileInput?.value ?? '';
+
+    if (turnstileWidget && !turnstileToken) {
+      dialogError.textContent = 'Please wait for the security check to complete.';
+      return;
+    }
+
     btnStripe.disabled = true;
     btnStripe.textContent = 'Redirecting…';
+    dialogError.textContent = '';
 
     try {
       const res = await fetch('/api/checkout', {
@@ -300,6 +321,7 @@ const schema = [
           productId: currentProduct.id,
           variantId: variant.id,
           quantity: 1,
+          turnstileToken: turnstileToken || 'dev',
         }),
       });
 
@@ -310,6 +332,7 @@ const schema = [
       dialogError.textContent = 'Something went wrong. Please try again.';
       btnStripe.disabled = false;
       btnStripe.textContent = 'Buy Now';
+      window.turnstile?.reset();
     }
   });
 </script>


### PR DESCRIPTION
## Summary
Three findings from a security pass on the payment flow, since real customer payments are going through it:

- **Open redirect**: `success_url`/`cancel_url` were built from the client-supplied `Origin` header, unvalidated. Anyone could call `/api/checkout` directly with a forged `Origin` and redirect a paying customer to an arbitrary domain after a real Stripe payment, with the real session id in the URL. Now uses a hardcoded `SITE_ORIGIN`.
- **No abuse protection**: `/api/checkout` had no rate-limit/CAPTCHA, unlike `/api/contact` (Turnstile). Extracted `verifyTurnstile` into `src/lib/turnstile.ts` and required it on checkout too — reuses the existing `TURNSTILE_SECRET_KEY`, no new secrets.
- **Error leaks**: raw exception text (`` `Stripe error: ${err}` ``) was returned directly in HTTP responses from both `checkout.ts` and `stripe-webhook.ts`. Still logged server-side; responses are now generic where the audience could include an attacker.

## Review follow-ups
- Turnstile's widget can silently never resolve (ad blocker, privacy extension, network block on `challenges.cloudflare.com`), which would otherwise leave the customer stuck on a "please wait" message forever. After an 8s grace period the message switches to actionable guidance instead.
- If `TURNSTILE_SECRET_KEY` is ever missing in production, `checkout.ts` now logs an error immediately rather than silently running with no abuse protection.
- Split the webhook's error responses by actual audience: the signature-check failure stays generic (that endpoint is public and reachable by bots with no valid signature at all), but the Printify-order-creation failure restores full error detail, since that path only runs after a verified Stripe signature — its only audience is Stripe's own retry logic and the webhook dashboard, so there's no attacker to withhold detail from.
- Moved the `Window.turnstile` ambient type declaration to the top of the script, next to the other declarations.

## Test plan
- [ ] Place a test order end-to-end, confirm Turnstile doesn't block a real purchase
- [ ] Confirm `curl -X POST /api/checkout -H "Origin: https://evil.com" ...` no longer produces a session pointing at `evil.com`
- [ ] Confirm error responses (e.g. bad product id) no longer include raw exception text
- [ ] Confirm the Printify-failure webhook response still shows real error detail (check Stripe's webhook dashboard after forcing a failure)