### PR TITLE
feat: send a refund confirmation email to the customer

### DIFF
--- a/SHOP.md
+++ b/SHOP.md
@@ -44,6 +44,14 @@ This is separate from the `SEND_EMAIL` binding used by the contact form, which s
 
 Stripe's own automatic payment-receipt email (Dashboard → Settings → Customer emails → "Successful payments") is a separate, independent toggle and worth enabling too — it's the payment record, not a replacement for the order-confirmation email above.
 
+## Refund Confirmation Email
+
+Sent from the webhook (`handleChargeRefunded` in `stripe-webhook.ts`) when Stripe fires `charge.refunded` — covers both full and partial refunds, and reflects the actual amount refunded (not necessarily the full order total). No merchant notification for this one; whoever issues the refund already knows it happened.
+
+**Requires a manual step**: the Stripe webhook endpoint must be subscribed to the `charge.refunded` event, not just `checkout.session.completed`. Check Stripe Dashboard → Developers → Webhooks → your endpoint → and add it to the selected events if it's not already there, or this code will simply never receive the event.
+
+Recipient email comes from the Charge object (`receipt_email` or `billing_details.email`) rather than looking up the original Checkout Session, so it works even without re-fetching anything — but it also means the email is intentionally generic (doesn't reference which item was refunded), since product/variant metadata isn't reliably available on the Charge object without an extra API round-trip.
+
 ## Dispute Notification
 
 Sent to `whiterabbitwcs@gmail.com` (`handleChargeDisputeCreated` in `stripe-webhook.ts`) when Stripe fires `charge.dispute.created`. Disputes are time-sensitive — Stripe auto-loses them if you don't submit evidence by the deadline, and charges a fee regardless of outcome — so the email includes the amount, reason, and response deadline, plus dashboard links to both the dispute and the original charge.

--- a/src/pages/api/stripe-webhook.ts
+++ b/src/pages/api/stripe-webhook.ts
@@ -94,6 +94,67 @@ async function handleChargeDisputeCreated(
   }
 }
 
+// Refunds are always initiated by the merchant (via Stripe dashboard or
+// API), so there's no equivalent "merchant notification" here -- whoever
+// issued the refund already knows. This only tells the customer.
+async function handleChargeRefunded(
+  event: Stripe.Event,
+  kv: Env['SESSION'] | undefined,
+  resendApiKey: string | undefined
+): Promise<void> {
+  const idempotencyKey = `stripe_event:${event.id}`;
+  if (kv) {
+    const already = await kv.get(idempotencyKey);
+    if (already) {
+      log(event.id, `Duplicate refund event, skipping`);
+      return;
+    }
+  } else {
+    logError(event.id, 'SESSION KV binding unavailable — idempotency check skipped, duplicate refund emails are possible');
+  }
+
+  const charge = event.data.object as Stripe.Charge;
+  const email = charge.receipt_email ?? charge.billing_details?.email ?? '';
+
+  if (email) {
+    const isFullRefund = charge.amount_refunded >= charge.amount;
+    const amountRefunded = new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: charge.currency.toUpperCase(),
+    }).format(charge.amount_refunded / 100);
+    const firstName = (charge.billing_details?.name ?? 'there').split(' ')[0];
+
+    try {
+      await sendResendEmail(resendApiKey, {
+        fromAddr: ORDER_FROM_ADDR,
+        fromName: ORDER_FROM_NAME,
+        to: email,
+        subject: isFullRefund ? 'Your White Rabbit order has been refunded' : 'A refund has been issued for your White Rabbit order',
+        text: [
+          `Hi ${firstName},`,
+          ``,
+          isFullRefund
+            ? `Your order has been fully refunded. ${amountRefunded} is on its way back to your original payment method.`
+            : `A partial refund of ${amountRefunded} has been issued back to your original payment method.`,
+          ``,
+          `It can take 5-10 business days to show up on your statement, depending on your bank.`,
+          ``,
+          `Questions? Just reply to this email.`,
+        ].join('\n'),
+      });
+      log(event.id, `Refund confirmation email sent to ${email}`);
+    } catch (err) {
+      logError(event.id, `Refund confirmation email failed for charge ${charge.id}`, err);
+    }
+  } else {
+    logError(event.id, `No email on charge ${charge.id} — refund confirmation skipped`);
+  }
+
+  if (kv) {
+    await kv.put(idempotencyKey, charge.id, { expirationTtl: 604800 });
+  }
+}
+
 export async function POST({ request, locals }: APIContext) {
   const env = (locals as { runtime?: { env?: Record<string, string> } }).runtime?.env ?? {};
 
@@ -136,6 +197,11 @@ export async function POST({ request, locals }: APIContext) {
 
   if (event.type === 'charge.dispute.created') {
     await handleChargeDisputeCreated(event, kv, merchantEmailBinding, stripeKey);
+    return new Response('OK', { status: 200 });
+  }
+
+  if (event.type === 'charge.refunded') {
+    await handleChargeRefunded(event, kv, resendApiKey);
     return new Response('OK', { status: 200 });
   }
 


### PR DESCRIPTION
## Summary
Extends the webhook-driven email pattern already used for order confirmations to Stripe's `charge.refunded` event.

- Covers both full and partial refunds, reflects the actual amount refunded
- Reuses the existing `sendResendEmail`/idempotency/logging infrastructure
- No merchant notification — refunds are always merchant-initiated, so whoever issued it already knows
- Recipient email comes from the Charge object directly (`receipt_email`/`billing_details.email`), so no extra API round-trip is needed — trade-off is the email can't reference which specific item was refunded

## Action required outside this repo
The Stripe webhook endpoint currently only sends `checkout.session.completed`. You'll need to add `charge.refunded` to the subscribed events in Stripe Dashboard → Developers → Webhooks → your endpoint, or this code will never receive the event.

## Test plan
- [ ] Subscribe the webhook endpoint to `charge.refunded`
- [ ] Issue a full refund on a test order, confirm the customer gets a "fully refunded" email with the correct amount
- [ ] Issue a partial refund, confirm the email correctly says "partial" and shows the partial amount