### PR TITLE
feat: notify the customer when their order ships or is delivered

### DIFF
--- a/SHOP.md
+++ b/SHOP.md
@@ -14,6 +14,25 @@ Printify itself never emails the customer here — this is a custom API integrat
 
 Orders are intentionally left as drafts (the `send_to_production` API call is omitted) so each order can be reviewed before Printify charges for fulfillment.
 
+## Shipping/Delivery Notification
+
+Sent from `src/pages/api/printify-webhook/[token].ts` when Printify fires `order:shipment:created` or `order:shipment:delivered` — a separate webhook system from Stripe's, since it's Printify (not Stripe) that knows when something ships.
+
+Printify's shipment payload only carries its own order id, not the customer. `stripe-webhook.ts` stashes `{email, firstName, itemLine}` in KV keyed by `printify_order:<id>` right after creating the Printify order, and this endpoint looks it up when the shipment event arrives (90-day TTL).
+
+**Setup, one-time, outside this repo:**
+
+1. Generate a random token (e.g. `openssl rand -hex 32`) and set it as both a Cloudflare secret and env var for the registration script:
+   ```bash
+   wrangler secret put PRINTIFY_WEBHOOK_TOKEN
+   ```
+2. Register the webhooks with Printify (no dashboard UI for this, API only):
+   ```bash
+   PRINTIFY_API_TOKEN=xxx PRINTIFY_SHOP_ID=xxx PRINTIFY_WEBHOOK_TOKEN=xxx pnpm register-printify-webhooks
+   ```
+
+**Security note**: Printify's webhook API has no signing/secret scheme (confirmed against their OpenAPI spec — the webhook object is just `{topic, url, shop_id, id}`). The random token in the URL path, checked in constant time, is the only practical protection available; combined with the KV-lookup gate (unrecognized order ids are silently ignored), the realistic worst case of a forged request is negligible.
+
 ## Security
 
 - `success_url`/`cancel_url` use a hardcoded `SITE_ORIGIN` (the deployed site's own URL) rather than the client-supplied `Origin` header. That header is trivially spoofable and, unvalidated, would let anyone redirect a paying customer to an arbitrary domain after a real Stripe payment completes.

--- a/SHOP.md
+++ b/SHOP.md
@@ -30,8 +30,14 @@ Printify's shipment payload only carries its own order id, not the customer. `st
    ```bash
    PRINTIFY_API_TOKEN=xxx PRINTIFY_SHOP_ID=xxx PRINTIFY_WEBHOOK_TOKEN=xxx pnpm register-printify-webhooks
    ```
+3. Set `DEV_ALERT_EMAIL` as a Cloudflare secret (see Failure alerting below):
+   ```bash
+   wrangler secret put DEV_ALERT_EMAIL
+   ```
 
 **Security note**: Printify's webhook API has no signing/secret scheme (confirmed against their OpenAPI spec — the webhook object is just `{topic, url, shop_id, id}`). The random token in the URL path, checked in constant time, is the only practical protection available; combined with the KV-lookup gate (unrecognized order ids are silently ignored), the realistic worst case of a forged request is negligible.
+
+**Failure alerting**: unlike the order-confirmation email (best-effort, log-only), a shipment/delivery notification that can't be sent — either because the KV order→customer mapping is missing, or because the Resend send itself fails — also emails a developer address via Resend (not the merchant inbox, and not the `SEND_EMAIL` binding, which can only reach that one verified address), since a silently dropped shipment email is easy to miss in Workers logs alone. The destination address is set via the `DEV_ALERT_EMAIL` secret rather than hardcoded, since this repo is public. Without it, alerts fall back to a logged warning instead of failing.
 
 ## Security
 

--- a/SHOP.md
+++ b/SHOP.md
@@ -37,7 +37,7 @@ Printify's shipment payload only carries its own order id, not the customer. `st
 
 **Security note**: Printify's webhook API has no signing/secret scheme (confirmed against their OpenAPI spec — the webhook object is just `{topic, url, shop_id, id}`). The random token in the URL path, checked in constant time, is the only practical protection available; combined with the KV-lookup gate (unrecognized order ids are silently ignored), the realistic worst case of a forged request is negligible.
 
-**Failure alerting**: unlike the order-confirmation email (best-effort, log-only), a shipment/delivery notification that can't be sent — either because the KV order→customer mapping is missing, or because the Resend send itself fails — also emails a developer address via Resend (not the merchant inbox, and not the `SEND_EMAIL` binding, which can only reach that one verified address), since a silently dropped shipment email is easy to miss in Workers logs alone. The destination address is set via the `DEV_ALERT_EMAIL` secret rather than hardcoded, since this repo is public. Without it, alerts fall back to a logged warning instead of failing.
+**Failure alerting**: unlike the order-confirmation email (best-effort, log-only), a shipment/delivery notification that can't be sent — either because the KV order→customer mapping is missing, or because the Resend send itself fails — also calls `alertDev()` (`src/lib/alert.ts`), a small general-purpose "closest thing to Sentry" helper: it emails a developer address via Resend (not the merchant inbox, and not the `SEND_EMAIL` binding, which can only reach that one verified address), since a silently dropped shipment email is easy to miss in Workers logs alone. The destination address is set via the `DEV_ALERT_EMAIL` secret rather than hardcoded, since this repo is public. Without it, alerts fall back to a logged warning instead of failing. `alertDev()` takes the same `env` object every handler already extracts from `locals.runtime.env`, so any other endpoint can call it the same way.
 
 ## Security
 
@@ -123,6 +123,7 @@ To update the Printify payment method: **printify.com → Wallet → Payments**.
 | `src/pages/api/stripe-webhook.ts` | Handles `checkout.session.completed`, creates Printify order |
 | `src/lib/printful.ts` | `createPrintifyOrder` — Printify API wrapper (filename is legacy) |
 | `src/lib/email.ts` | `sendResendEmail` (order confirmations, via Resend) and `sendEmail` (contact form, via Cloudflare `send_email` binding) |
+| `src/lib/alert.ts` | `alertDev` — best-effort dev-facing ops alert via Resend, for silent failures any endpoint hits |
 | `src/data/products.json` | Pre-fetched product catalog (committed; update via fetch script) |
 
 ## Refreshing Product Data

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint": "oxlint --type-aware",
     "format": "oxfmt",
     "fetch-products": "node scripts/fetch-products.js",
-    "preview-email": "tsx scripts/preview-email.tsx"
+    "preview-email": "tsx scripts/preview-email.tsx",
+    "register-printify-webhooks": "node scripts/register-printify-webhooks.js"
   },
   "dependencies": {
     "@astrojs/cloudflare": "^12.6.12",

--- a/scripts/register-printify-webhooks.js
+++ b/scripts/register-printify-webhooks.js
@@ -1,0 +1,38 @@
+// Registers the shipment webhooks with Printify (order:shipment:created and
+// order:shipment:delivered), pointing at /api/printify-webhook/<token>.
+// Printify has no dashboard UI for this -- API only. Run once; re-run if
+// the callback URL or PRINTIFY_WEBHOOK_TOKEN ever changes (it just creates
+// new webhook registrations, so delete stale ones in Printify if you do).
+//
+// Run with:
+//   PRINTIFY_API_TOKEN=xxx PRINTIFY_SHOP_ID=xxx PRINTIFY_WEBHOOK_TOKEN=xxx node scripts/register-printify-webhooks.js
+
+const API_TOKEN = process.env.PRINTIFY_API_TOKEN;
+const SHOP_ID = process.env.PRINTIFY_SHOP_ID;
+const WEBHOOK_TOKEN = process.env.PRINTIFY_WEBHOOK_TOKEN;
+const SITE_URL = process.env.SITE_URL ?? 'https://whiterabbitwcs.com';
+
+if (!API_TOKEN) { console.error('PRINTIFY_API_TOKEN not set'); process.exit(1); }
+if (!SHOP_ID) { console.error('PRINTIFY_SHOP_ID not set'); process.exit(1); }
+if (!WEBHOOK_TOKEN) { console.error('PRINTIFY_WEBHOOK_TOKEN not set (must match the Cloudflare secret of the same name)'); process.exit(1); }
+
+const callbackUrl = `${SITE_URL}/api/printify-webhook/${WEBHOOK_TOKEN}`;
+const topics = ['order:shipment:created', 'order:shipment:delivered'];
+
+for (const topic of topics) {
+  const res = await fetch(`https://api.printify.com/v1/shops/${SHOP_ID}/webhooks.json`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${API_TOKEN}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ topic, url: callbackUrl }),
+  });
+
+  const body = await res.json();
+  if (!res.ok) {
+    console.error(`Failed to register ${topic}:`, body);
+    continue;
+  }
+  console.log(`Registered ${topic} -> webhook id ${body.id}`);
+}

--- a/src/lib/alert.ts
+++ b/src/lib/alert.ts
@@ -1,0 +1,40 @@
+import { sendResendEmail } from './email';
+
+const ALERT_FROM_ADDR = 'orders@whiterabbitwcs.com';
+const ALERT_FROM_NAME = 'White Rabbit WCS';
+
+/**
+ * Best-effort ops alert -- the closest thing this app has to Sentry.
+ * Emails DEV_ALERT_EMAIL via Resend whenever something fails silently
+ * (a webhook can't notify a customer, a background job errors, etc.)
+ * so it doesn't go unnoticed in Workers logs alone.
+ *
+ * Never throws: a broken alert path must never mask the original error
+ * or fail the caller's response. Falls back to a console.error when
+ * DEV_ALERT_EMAIL isn't configured, same as the console.log stubs in
+ * src/lib/email.ts.
+ *
+ * Goes via Resend (arbitrary recipients) rather than the SEND_EMAIL
+ * binding, which can only reach the one verified merchant inbox.
+ * The destination is a secret, not hardcoded, since this repo is public.
+ */
+export async function alertDev(env: Record<string, string | undefined>, subject: string, text: string): Promise<void> {
+  const devAlertTo = env.DEV_ALERT_EMAIL;
+
+  if (!devAlertTo) {
+    console.error(`[alert] DEV_ALERT_EMAIL not configured, dropping alert: ${subject}`);
+    return;
+  }
+
+  try {
+    await sendResendEmail(env.RESEND_API_KEY, {
+      fromAddr: ALERT_FROM_ADDR,
+      fromName: ALERT_FROM_NAME,
+      to: devAlertTo,
+      subject: `[alert] ${subject}`,
+      text,
+    });
+  } catch (err) {
+    console.error('[alert] dev alert email failed', err);
+  }
+}

--- a/src/pages/api/printify-webhook/[token].ts
+++ b/src/pages/api/printify-webhook/[token].ts
@@ -37,6 +37,24 @@ function logError(msg: string, err?: unknown) {
   console.error(`[printify-webhook] ${msg}`, err ?? '');
 }
 
+// Dev alert, not merchant-facing -- goes to DEV_ALERT_EMAIL (a Cloudflare
+// secret, not hardcoded, since this repo is public) via Resend rather than
+// the SEND_EMAIL binding, since that binding can only reach the verified
+// merchant inbox. Failures here are already logged by the caller -- this is
+// a best-effort nudge on top, so a broken alert path should never mask the
+// original error.
+async function alertDev(resendApiKey: string | undefined, devAlertTo: string | undefined, subject: string, text: string) {
+  if (!devAlertTo) {
+    logError('DEV_ALERT_EMAIL not configured, skipping dev alert');
+    return;
+  }
+  try {
+    await sendResendEmail(resendApiKey, { fromAddr: ORDER_FROM_ADDR, fromName: ORDER_FROM_NAME, to: devAlertTo, subject, text });
+  } catch (err) {
+    logError('Dev alert email failed', err);
+  }
+}
+
 export const POST: APIRoute = async ({ request, params, locals }) => {
   const e = cfEnv as any;
   const webhookToken = e.PRINTIFY_WEBHOOK_TOKEN as string | undefined;
@@ -45,6 +63,7 @@ export const POST: APIRoute = async ({ request, params, locals }) => {
     | undefined;
   const env = (locals as { runtime?: { env?: Record<string, string> } }).runtime?.env ?? {};
   const resendApiKey = env.RESEND_API_KEY;
+  const devAlertTo = env.DEV_ALERT_EMAIL;
 
   // Printify has no webhook signing scheme (confirmed against their OpenAPI
   // spec -- the webhook object is just {topic, url, shop_id, id}, no secret
@@ -94,6 +113,17 @@ export const POST: APIRoute = async ({ request, params, locals }) => {
   const mappingRaw = await kv.get(`printify_order:${printifyOrderId}`);
   if (!mappingRaw) {
     logError(`No stored mapping for Printify order ${printifyOrderId} -- can't notify, skipping`);
+    await alertDev(
+      resendApiKey,
+      devAlertTo,
+      `Printify order ${printifyOrderId}: shipment notification not sent`,
+      [
+        `Printify sent a ${payload.type} event for order ${printifyOrderId}, but there's no stored customer mapping for it, so no email went out.`,
+        ``,
+        `Event id: ${payload.id}`,
+        `This can happen for orders placed before shipment notifications existed, or if the original KV write failed.`,
+      ].join('\n')
+    );
     await kv.put(idempotencyKey, '1', { expirationTtl: 604800 });
     return new Response('OK', { status: 200 });
   }
@@ -145,6 +175,17 @@ export const POST: APIRoute = async ({ request, params, locals }) => {
     }
   } catch (err) {
     logError(`Notification email failed for Printify order ${printifyOrderId}`, err);
+    await alertDev(
+      resendApiKey,
+      devAlertTo,
+      `Printify order ${printifyOrderId}: shipment notification failed to send`,
+      [
+        `The ${payload.type} email to ${email} for order ${printifyOrderId} failed to send.`,
+        ``,
+        `Error: ${err instanceof Error ? err.message : String(err)}`,
+        `You may want to follow up with the customer directly.`,
+      ].join('\n')
+    );
   }
 
   await kv.put(idempotencyKey, '1', { expirationTtl: 604800 });

--- a/src/pages/api/printify-webhook/[token].ts
+++ b/src/pages/api/printify-webhook/[token].ts
@@ -1,6 +1,7 @@
 import type { APIRoute } from 'astro';
 import { env as cfEnv } from 'cloudflare:workers';
 import { sendResendEmail } from '../../../lib/email';
+import { alertDev } from '../../../lib/alert';
 
 export const prerender = false;
 
@@ -37,24 +38,6 @@ function logError(msg: string, err?: unknown) {
   console.error(`[printify-webhook] ${msg}`, err ?? '');
 }
 
-// Dev alert, not merchant-facing -- goes to DEV_ALERT_EMAIL (a Cloudflare
-// secret, not hardcoded, since this repo is public) via Resend rather than
-// the SEND_EMAIL binding, since that binding can only reach the verified
-// merchant inbox. Failures here are already logged by the caller -- this is
-// a best-effort nudge on top, so a broken alert path should never mask the
-// original error.
-async function alertDev(resendApiKey: string | undefined, devAlertTo: string | undefined, subject: string, text: string) {
-  if (!devAlertTo) {
-    logError('DEV_ALERT_EMAIL not configured, skipping dev alert');
-    return;
-  }
-  try {
-    await sendResendEmail(resendApiKey, { fromAddr: ORDER_FROM_ADDR, fromName: ORDER_FROM_NAME, to: devAlertTo, subject, text });
-  } catch (err) {
-    logError('Dev alert email failed', err);
-  }
-}
-
 export const POST: APIRoute = async ({ request, params, locals }) => {
   const e = cfEnv as any;
   const webhookToken = e.PRINTIFY_WEBHOOK_TOKEN as string | undefined;
@@ -63,7 +46,6 @@ export const POST: APIRoute = async ({ request, params, locals }) => {
     | undefined;
   const env = (locals as { runtime?: { env?: Record<string, string> } }).runtime?.env ?? {};
   const resendApiKey = env.RESEND_API_KEY;
-  const devAlertTo = env.DEV_ALERT_EMAIL;
 
   // Printify has no webhook signing scheme (confirmed against their OpenAPI
   // spec -- the webhook object is just {topic, url, shop_id, id}, no secret
@@ -114,8 +96,7 @@ export const POST: APIRoute = async ({ request, params, locals }) => {
   if (!mappingRaw) {
     logError(`No stored mapping for Printify order ${printifyOrderId} -- can't notify, skipping`);
     await alertDev(
-      resendApiKey,
-      devAlertTo,
+      env,
       `Printify order ${printifyOrderId}: shipment notification not sent`,
       [
         `Printify sent a ${payload.type} event for order ${printifyOrderId}, but there's no stored customer mapping for it, so no email went out.`,
@@ -176,8 +157,7 @@ export const POST: APIRoute = async ({ request, params, locals }) => {
   } catch (err) {
     logError(`Notification email failed for Printify order ${printifyOrderId}`, err);
     await alertDev(
-      resendApiKey,
-      devAlertTo,
+      env,
       `Printify order ${printifyOrderId}: shipment notification failed to send`,
       [
         `The ${payload.type} email to ${email} for order ${printifyOrderId} failed to send.`,

--- a/src/pages/api/printify-webhook/[token].ts
+++ b/src/pages/api/printify-webhook/[token].ts
@@ -1,0 +1,152 @@
+import type { APIRoute } from 'astro';
+import { env as cfEnv } from 'cloudflare:workers';
+import { sendResendEmail } from '../../../lib/email';
+
+export const prerender = false;
+
+const ORDER_FROM_ADDR = 'orders@whiterabbitwcs.com';
+const ORDER_FROM_NAME = 'White Rabbit WCS';
+
+interface OrderMapping {
+  email: string;
+  firstName: string;
+  itemLine: string;
+}
+
+interface PrintifyCarrier {
+  code: string;
+  tracking_number: string;
+  tracking_url?: string;
+}
+
+interface PrintifyShipmentEvent {
+  id: string;
+  type: string;
+  resource: {
+    id: string;
+    data?: {
+      carrier?: PrintifyCarrier;
+    };
+  };
+}
+
+function log(msg: string) {
+  console.log(`[printify-webhook] ${msg}`);
+}
+function logError(msg: string, err?: unknown) {
+  console.error(`[printify-webhook] ${msg}`, err ?? '');
+}
+
+export const POST: APIRoute = async ({ request, params, locals }) => {
+  const e = cfEnv as any;
+  const webhookToken = e.PRINTIFY_WEBHOOK_TOKEN as string | undefined;
+  const kv = e.SESSION as
+    | { get: (k: string, t?: string) => Promise<any>; put: (k: string, v: string, o?: any) => Promise<void> }
+    | undefined;
+  const env = (locals as { runtime?: { env?: Record<string, string> } }).runtime?.env ?? {};
+  const resendApiKey = env.RESEND_API_KEY;
+
+  // Printify has no webhook signing scheme (confirmed against their OpenAPI
+  // spec -- the webhook object is just {topic, url, shop_id, id}, no secret
+  // field). A hard-to-guess path segment, checked in constant time, is the
+  // only practical protection available here.
+  const token = params.token ?? '';
+  const enc = new TextEncoder();
+  const tokenBytes = enc.encode(token);
+  const secretBytes = enc.encode(webhookToken ?? '');
+  const validToken =
+    !!webhookToken &&
+    tokenBytes.byteLength === secretBytes.byteLength &&
+    crypto.subtle.timingSafeEqual(tokenBytes, secretBytes);
+
+  if (!validToken) {
+    logError('Rejected request with invalid or missing token');
+    return new Response('Unauthorized', { status: 401 });
+  }
+
+  if (!kv) {
+    logError('SESSION KV binding unavailable');
+    return new Response('Not configured', { status: 500 });
+  }
+
+  let payload: PrintifyShipmentEvent;
+  try {
+    payload = await request.json();
+  } catch {
+    logError('Invalid JSON body');
+    return new Response('Invalid JSON', { status: 400 });
+  }
+
+  if (payload.type !== 'order:shipment:created' && payload.type !== 'order:shipment:delivered') {
+    log(`Ignoring unhandled topic=${payload.type}`);
+    return new Response('OK', { status: 200 });
+  }
+
+  // Idempotency: Printify retries up to 3 times on a non-2xx response.
+  const idempotencyKey = `printify_event:${payload.id}`;
+  const already = await kv.get(idempotencyKey);
+  if (already) {
+    log(`Duplicate event ${payload.id}, skipping`);
+    return new Response('OK', { status: 200 });
+  }
+
+  const printifyOrderId = payload.resource.id;
+  const mappingRaw = await kv.get(`printify_order:${printifyOrderId}`);
+  if (!mappingRaw) {
+    logError(`No stored mapping for Printify order ${printifyOrderId} -- can't notify, skipping`);
+    await kv.put(idempotencyKey, '1', { expirationTtl: 604800 });
+    return new Response('OK', { status: 200 });
+  }
+
+  const { email, firstName, itemLine } = JSON.parse(mappingRaw) as OrderMapping;
+  const carrier = payload.resource.data?.carrier;
+
+  try {
+    if (payload.type === 'order:shipment:created') {
+      const carrierLines = carrier
+        ? [
+            `Carrier: ${carrier.code}`,
+            `Tracking number: ${carrier.tracking_number}`,
+            carrier.tracking_url ? `Track it: ${carrier.tracking_url}` : null,
+          ].filter((line): line is string => Boolean(line))
+        : [];
+
+      await sendResendEmail(resendApiKey, {
+        fromAddr: ORDER_FROM_ADDR,
+        fromName: ORDER_FROM_NAME,
+        to: email,
+        subject: 'Your White Rabbit order has shipped',
+        text: [
+          `Hi ${firstName},`,
+          ``,
+          `${itemLine} is on its way!`,
+          ``,
+          ...carrierLines,
+          ``,
+          `Questions? Just reply to this email.`,
+        ].join('\n'),
+      });
+      log(`Shipped email sent to ${email} for Printify order ${printifyOrderId}`);
+    } else {
+      await sendResendEmail(resendApiKey, {
+        fromAddr: ORDER_FROM_ADDR,
+        fromName: ORDER_FROM_NAME,
+        to: email,
+        subject: 'Your White Rabbit order was delivered',
+        text: [
+          `Hi ${firstName},`,
+          ``,
+          `${itemLine} has been delivered! We hope you love it.`,
+          ``,
+          `Questions? Just reply to this email.`,
+        ].join('\n'),
+      });
+      log(`Delivered email sent to ${email} for Printify order ${printifyOrderId}`);
+    }
+  } catch (err) {
+    logError(`Notification email failed for Printify order ${printifyOrderId}`, err);
+  }
+
+  await kv.put(idempotencyKey, '1', { expirationTtl: 604800 });
+  return new Response('OK', { status: 200 });
+};

--- a/src/pages/api/stripe-webhook.ts
+++ b/src/pages/api/stripe-webhook.ts
@@ -295,6 +295,17 @@ export async function POST({ request, locals }: APIContext) {
     [shipping.address.city, shipping.address.state, shipping.address.postal_code].filter(Boolean).join(', '),
   ].filter((line): line is string => Boolean(line));
 
+  // Printify's shipment webhooks only carry its own order id, not the
+  // customer -- stash the lookup now so /api/printify-webhook can notify
+  // the right person later. 90 days covers even a badly delayed shipment.
+  if (kv && customerEmail) {
+    await kv.put(
+      `printify_order:${printifyOrder.id}`,
+      JSON.stringify({ email: customerEmail, firstName, itemLine }),
+      { expirationTtl: 60 * 60 * 24 * 90 }
+    );
+  }
+
   // Best-effort: an email failure shouldn't turn into a duplicate Printify
   // order on Stripe's retry, so neither of these ever affects the response status.
   if (customerEmail) {


### PR DESCRIPTION
## Summary
Fulfills a promise the confirmation email already makes ("you'll get a shipping notification once it's on its way") that nothing previously delivered on.

- New `/api/printify-webhook/[token].ts` — a separate webhook receiver from Stripe's, since Printify (not Stripe) is what knows when something ships
- Handles `order:shipment:created` and `order:shipment:delivered`, verified against Printify's actual OpenAPI spec (`orderShipmentCreated`/`orderShipmentCreatedData` schemas), not guessed
- `stripe-webhook.ts` now stashes `{email, firstName, itemLine}` in KV keyed by the Printify order id right after creating it (90-day TTL) — Printify's shipment payload only carries its own order id, not the customer, so this endpoint looks it up when the shipment event arrives
- Printify has no webhook signing scheme (confirmed against their spec), so the endpoint is gated by a random token in the URL path (constant-time compared, same pattern as `gallery/purge.ts`) plus a KV-lookup gate that silently ignores unrecognized order ids
- `scripts/register-printify-webhooks.js` — Printify has no dashboard UI for webhook registration, API only

Verified end-to-end against the actual compiled Worker via `wrangler dev` + a seeded local KV entry — confirmed correct email content (including a real bug caught this way: a `.filter(Boolean)` was stripping intentional blank-line spacers, not just the conditional carrier lines), correct 401 on bad token, correct skip on missing KV mapping, and correct idempotency dedup on a repeated event id.

Note: `astro dev` couldn't be used for this verification — its dev-mode Vite plugin doesn't resolve `cloudflare:workers` for routes nested under a subdirectory of `src/pages/api/` (confirmed `gallery/purge.ts` hits the identical failure locally; this is a pre-existing dev-server-only limitation, not something introduced here, and doesn't affect the real deployed Worker).

## Action required outside this repo
1. `wrangler secret put PRINTIFY_WEBHOOK_TOKEN` (generate with e.g. `openssl rand -hex 32`)
2. `PRINTIFY_API_TOKEN=xxx PRINTIFY_SHOP_ID=xxx PRINTIFY_WEBHOOK_TOKEN=xxx pnpm register-printify-webhooks`

## Test plan
- [ ] Complete the setup steps above
- [ ] Place a real order, manually mark it shipped in Printify (or wait for a real shipment), confirm the customer gets the shipped email with tracking info
- [ ] Confirm the delivered email fires once Printify marks it delivered