### PR TITLE
feat: brand shipment emails, make dev alert actionable, fix success-page icon

### DIFF
--- a/scripts/preview-email.tsx
+++ b/scripts/preview-email.tsx
@@ -1,7 +1,7 @@
-// Renders src/emails/OrderConfirmation.tsx to HTML with sample data and
-// opens it in the browser. No Stripe/Printify/Resend involved — for fast
-// iteration on email copy/design only.
-// Run with: pnpm preview-email
+// Renders one of src/emails/*.tsx to HTML with sample data and opens it in
+// the browser. No Stripe/Printify/Resend involved -- for fast iteration on
+// email copy/design only.
+// Run with: pnpm preview-email [confirmation|shipped|delivered]
 
 import { writeFileSync } from 'fs';
 import { join, dirname } from 'path';
@@ -9,6 +9,8 @@ import { fileURLToPath } from 'url';
 import { execFileSync } from 'child_process';
 import { render } from '@react-email/render';
 import { OrderConfirmationEmail } from '../src/emails/OrderConfirmation';
+import { OrderShippedEmail } from '../src/emails/OrderShipped';
+import { OrderDeliveredEmail } from '../src/emails/OrderDelivered';
 import productsData from '../src/data/products.json' with { type: 'json' };
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -17,19 +19,37 @@ type Product = { name: string; variants: { name: string; price: string }[] };
 const products = productsData as Product[];
 const sampleProduct = products[0];
 const sampleVariant = sampleProduct?.variants[0];
+const sampleItemLine = sampleProduct
+  ? `1 x ${sampleProduct.name}${sampleVariant ? ` (${sampleVariant.name})` : ''}`
+  : '1 x Sample Product';
 
-const html = await render(
-  OrderConfirmationEmail({
-    firstName: 'Alex',
-    itemLine: sampleProduct
-      ? `1 x ${sampleProduct.name}${sampleVariant ? ` (${sampleVariant.name})` : ''}`
-      : '1 x Sample Product',
-    amountPaid: sampleVariant
-      ? new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(parseFloat(sampleVariant.price))
-      : '$35.00',
-    addressLines: ['Alex Rivera', '123 Main St', 'Apt 4B', 'Phoenix, AZ 85001'],
-  })
-);
+const template = process.argv[2] ?? 'confirmation';
+
+const templates = {
+  confirmation: () =>
+    OrderConfirmationEmail({
+      firstName: 'Alex',
+      itemLine: sampleItemLine,
+      amountPaid: sampleVariant
+        ? new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(parseFloat(sampleVariant.price))
+        : '$35.00',
+      addressLines: ['Alex Rivera', '123 Main St', 'Apt 4B', 'Phoenix, AZ 85001'],
+    }),
+  shipped: () =>
+    OrderShippedEmail({
+      firstName: 'Alex',
+      itemLine: sampleItemLine,
+      carrier: { code: 'usps', trackingNumber: '9400111899223344556677', trackingUrl: 'https://tools.usps.com/go/TrackConfirmAction' },
+    }),
+  delivered: () => OrderDeliveredEmail({ firstName: 'Alex', itemLine: sampleItemLine }),
+};
+
+if (!(template in templates)) {
+  console.error(`Unknown template "${template}". Choose one of: ${Object.keys(templates).join(', ')}`);
+  process.exit(1);
+}
+
+const html = await render(templates[template as keyof typeof templates]());
 
 const outPath = join(__dirname, '..', '.email-preview.html');
 writeFileSync(outPath, html);

--- a/src/emails/OrderConfirmation.tsx
+++ b/src/emails/OrderConfirmation.tsx
@@ -9,6 +9,7 @@ import {
   Section,
   Text,
 } from '@react-email/components';
+import { colors, fontMono, fontSans } from './theme';
 
 export interface OrderConfirmationEmailProps {
   firstName: string;
@@ -16,18 +17,6 @@ export interface OrderConfirmationEmailProps {
   amountPaid: string | null;
   addressLines: string[];
 }
-
-const colors = {
-  bg: '#0d0d0d',
-  card: '#1a1a1a',
-  accent: '#00ff41',
-  text: '#f0f0f0',
-  textMuted: '#b0b0b0',
-  border: 'rgba(255, 255, 255, 0.15)',
-};
-
-const fontMono = '"Courier New", Courier, monospace';
-const fontSans = '-apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif';
 
 export function OrderConfirmationEmail({ firstName, itemLine, amountPaid, addressLines }: OrderConfirmationEmailProps) {
   return (

--- a/src/emails/OrderDelivered.tsx
+++ b/src/emails/OrderDelivered.tsx
@@ -1,0 +1,46 @@
+import { Body, Container, Head, Heading, Hr, Html, Preview, Text } from '@react-email/components';
+import { colors, fontMono, fontSans } from './theme';
+
+export interface OrderDeliveredEmailProps {
+  firstName: string;
+  itemLine: string;
+}
+
+export function OrderDeliveredEmail({ firstName, itemLine }: OrderDeliveredEmailProps) {
+  return (
+    <Html>
+      <Head />
+      <Preview>Your White Rabbit order has been delivered</Preview>
+      <Body style={{ backgroundColor: colors.bg, fontFamily: fontSans, margin: 0, padding: '32px 0' }}>
+        <Container style={{ maxWidth: 480, margin: '0 auto', padding: '0 24px' }}>
+          <Text style={{ fontSize: 36, textAlign: 'center', margin: '0 0 8px' }}>🐰🎉</Text>
+          <Heading
+            style={{
+              color: colors.accent,
+              fontFamily: fontMono,
+              fontSize: 26,
+              letterSpacing: 2,
+              textAlign: 'center',
+              margin: '0 0 24px',
+            }}
+          >
+            DELIVERED
+          </Heading>
+          <Text style={{ color: colors.text, fontSize: 16, lineHeight: '26px', textAlign: 'center', margin: 0 }}>
+            Hi {firstName}, {itemLine} just landed on your doorstep.
+          </Text>
+          <Text style={{ color: colors.textMuted, fontSize: 14, lineHeight: '22px', textAlign: 'center', margin: '24px 0 0' }}>
+            Time to lace up and put it through its paces on the floor. We hope
+            it upgrades your dance floor swagger exactly as promised.
+          </Text>
+          <Hr style={{ borderColor: colors.border, margin: '24px 0' }} />
+          <Text style={{ color: colors.textMuted, fontSize: 13, textAlign: 'center', margin: 0 }}>
+            Questions? Just reply to this email.
+          </Text>
+        </Container>
+      </Body>
+    </Html>
+  );
+}
+
+export default OrderDeliveredEmail;

--- a/src/emails/OrderShipped.tsx
+++ b/src/emails/OrderShipped.tsx
@@ -1,0 +1,106 @@
+import {
+  Body,
+  Button,
+  Container,
+  Head,
+  Heading,
+  Hr,
+  Html,
+  Preview,
+  Section,
+  Text,
+} from '@react-email/components';
+import { colors, fontMono, fontSans } from './theme';
+
+export interface OrderShippedEmailProps {
+  firstName: string;
+  itemLine: string;
+  carrier?: {
+    code: string;
+    trackingNumber: string;
+    trackingUrl?: string;
+  };
+}
+
+export function OrderShippedEmail({ firstName, itemLine, carrier }: OrderShippedEmailProps) {
+  return (
+    <Html>
+      <Head />
+      <Preview>Your White Rabbit order is on its way</Preview>
+      <Body style={{ backgroundColor: colors.bg, fontFamily: fontSans, margin: 0, padding: '32px 0' }}>
+        <Container style={{ maxWidth: 480, margin: '0 auto', padding: '0 24px' }}>
+          <Text style={{ fontSize: 36, textAlign: 'center', margin: '0 0 8px' }}>🐰💨</Text>
+          <Heading
+            style={{
+              color: colors.accent,
+              fontFamily: fontMono,
+              fontSize: 26,
+              letterSpacing: 2,
+              textAlign: 'center',
+              margin: '0 0 24px',
+            }}
+          >
+            ON ITS WAY
+          </Heading>
+          <Text style={{ color: colors.text, fontSize: 16, lineHeight: '26px', textAlign: 'center', margin: 0 }}>
+            Hi {firstName}, {itemLine} just hopped out of the warehouse and is headed your way.
+          </Text>
+          {carrier && (
+            <Section
+              style={{
+                backgroundColor: colors.card,
+                border: `1px solid ${colors.border}`,
+                borderRadius: 8,
+                padding: '20px',
+                margin: '24px 0',
+                textAlign: 'center',
+              }}
+            >
+              <Text
+                style={{
+                  color: colors.textMuted,
+                  fontSize: 11,
+                  margin: '0 0 6px',
+                  textTransform: 'uppercase',
+                  letterSpacing: 1,
+                }}
+              >
+                {carrier.code}
+              </Text>
+              <Text style={{ color: colors.text, fontFamily: fontMono, fontSize: 16, margin: '0 0 16px' }}>
+                {carrier.trackingNumber}
+              </Text>
+              {carrier.trackingUrl && (
+                <Button
+                  href={carrier.trackingUrl}
+                  style={{
+                    backgroundColor: colors.accent,
+                    color: colors.bg,
+                    fontFamily: fontMono,
+                    fontSize: 13,
+                    fontWeight: 700,
+                    letterSpacing: 1,
+                    borderRadius: 6,
+                    padding: '10px 24px',
+                    textDecoration: 'none',
+                  }}
+                >
+                  TRACK PACKAGE
+                </Button>
+              )}
+            </Section>
+          )}
+          <Text style={{ color: colors.textMuted, fontSize: 14, lineHeight: '22px', textAlign: 'center' }}>
+            It&apos;s making its way through the rabbit hole straight to your door. Hang tight.
+          </Text>
+          <Hr style={{ borderColor: colors.border, margin: '24px 0' }} />
+          <Text style={{ color: colors.textMuted, fontSize: 13, textAlign: 'center', margin: 0 }}>
+            Questions? Just reply to this email.
+          </Text>
+        </Container>
+      </Body>
+    </Html>
+  );
+}
+
+export default OrderShippedEmail;

--- a/src/emails/theme.ts
+++ b/src/emails/theme.ts
@@ -1,0 +1,11 @@
+export const colors = {
+  bg: '#0d0d0d',
+  card: '#1a1a1a',
+  accent: '#00ff41',
+  text: '#f0f0f0',
+  textMuted: '#b0b0b0',
+  border: 'rgba(255, 255, 255, 0.15)',
+};
+
+export const fontMono = '"Courier New", Courier, monospace';
+export const fontSans = '-apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif';

--- a/src/pages/api/printify-webhook/[token].ts
+++ b/src/pages/api/printify-webhook/[token].ts
@@ -1,7 +1,10 @@
 import type { APIRoute } from 'astro';
 import { env as cfEnv } from 'cloudflare:workers';
+import { render } from '@react-email/render';
 import { sendResendEmail } from '../../../lib/email';
 import { alertDev } from '../../../lib/alert';
+import { OrderShippedEmail } from '../../../emails/OrderShipped';
+import { OrderDeliveredEmail } from '../../../emails/OrderDelivered';
 
 export const prerender = false;
 
@@ -101,8 +104,17 @@ export const POST: APIRoute = async ({ request, params, locals }) => {
       [
         `Printify sent a ${payload.type} event for order ${printifyOrderId}, but there's no stored customer mapping for it, so no email went out.`,
         ``,
+        `Likely cause: this order was placed before shipment notifications existed (no mapping was ever written), or the original KV write in stripe-webhook.ts failed at checkout time.`,
+        ``,
+        `To fix: look up order ${printifyOrderId} in the Printify dashboard's Orders search to find the customer's email and item, then either email them directly or re-seed the mapping so a future shipment event on this order picks it up automatically:`,
+        ``,
+        `  wrangler kv key put --binding=SESSION "printify_order:${printifyOrderId}" '{"email":"<their email>","firstName":"<first name>","itemLine":"<item description>"}' --remote --expiration-ttl 7776000`,
+        ``,
         `Event id: ${payload.id}`,
-        `This can happen for orders placed before shipment notifications existed, or if the original KV write failed.`,
+        `Event type: ${payload.type}`,
+        ``,
+        `Raw event payload:`,
+        JSON.stringify(payload, null, 2),
       ].join('\n')
     );
     await kv.put(idempotencyKey, '1', { expirationTtl: 604800 });
@@ -122,11 +134,22 @@ export const POST: APIRoute = async ({ request, params, locals }) => {
           ].filter((line): line is string => Boolean(line))
         : [];
 
+      const html = await render(
+        OrderShippedEmail({
+          firstName,
+          itemLine,
+          carrier: carrier
+            ? { code: carrier.code, trackingNumber: carrier.tracking_number, trackingUrl: carrier.tracking_url }
+            : undefined,
+        })
+      );
+
       await sendResendEmail(resendApiKey, {
         fromAddr: ORDER_FROM_ADDR,
         fromName: ORDER_FROM_NAME,
         to: email,
         subject: 'Your White Rabbit order has shipped',
+        html,
         text: [
           `Hi ${firstName},`,
           ``,
@@ -139,11 +162,14 @@ export const POST: APIRoute = async ({ request, params, locals }) => {
       });
       log(`Shipped email sent to ${email} for Printify order ${printifyOrderId}`);
     } else {
+      const html = await render(OrderDeliveredEmail({ firstName, itemLine }));
+
       await sendResendEmail(resendApiKey, {
         fromAddr: ORDER_FROM_ADDR,
         fromName: ORDER_FROM_NAME,
         to: email,
         subject: 'Your White Rabbit order was delivered',
+        html,
         text: [
           `Hi ${firstName},`,
           ``,

--- a/src/pages/shop/success.astro
+++ b/src/pages/shop/success.astro
@@ -38,15 +38,15 @@ import Layout from '../../layouts/Layout.astro';
   }
 
   .result-icon {
-    width: 72px;
-    height: 72px;
+    width: 88px;
+    height: 88px;
     border-radius: 50%;
-    background: var(--accent-primary);
+    background: var(--bg-secondary);
+    border: 2px solid var(--accent-primary);
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: 1.7rem;
-    letter-spacing: -2px;
+    font-size: 2.25rem;
   }
 
   .result-title {


### PR DESCRIPTION
## Summary
Follow-up to #84 — polish pass on the shipment-notification feature.

- `OrderShipped`/`OrderDelivered` React-Email templates (matching the existing order-confirmation design) so shipment/delivery emails get the same dark/neon Matrix branding instead of plain text. Shipped email includes a tracking card + "TRACK PACKAGE" button.
- Extracted shared brand tokens (colors, fonts) to `src/emails/theme.ts`, used by all three email templates now.
- `scripts/preview-email.tsx` now takes an arg (`pnpm preview-email shipped|delivered|confirmation`) to preview any of the three locally, no live send needed.
- The "missing KV mapping" dev alert is now actionable: includes likely cause, a ready-to-run `wrangler kv key put` command to fix it, and the raw event payload — previously it was just a one-line description.
- Fixed `shop/success.astro`: the 🐰👍 emoji sat on a solid green circle that clashed with the emoji's own colors. Switched to the same outlined-circle style already used on the cancel page.

## Verification
- Rendered all three email templates locally via `pnpm preview-email` and reviewed in browser.
- Ran `pnpm lint` — no new issues (the ones reported are pre-existing/unrelated to this diff).
- Confirmed against the actual production endpoint in the parent feature (#84) that shipped/delivered emails send successfully; this PR only changes their content (plain text → HTML) and the alert's payload, not the send path or auth/idempotency logic.

## Test plan
- [ ] Visually review the shipped/delivered email templates via `pnpm preview-email shipped` / `pnpm preview-email delivered`
- [ ] Confirm the success page icon renders correctly across themes (not just the default dark/green one)