### PR TITLE
feat: brand the refund confirmation email

### DIFF
--- a/scripts/preview-email.tsx
+++ b/scripts/preview-email.tsx
@@ -1,7 +1,7 @@
 // Renders one of src/emails/*.tsx to HTML with sample data and opens it in
 // the browser. No Stripe/Printify/Resend involved -- for fast iteration on
 // email copy/design only.
-// Run with: pnpm preview-email [confirmation|shipped|delivered]
+// Run with: pnpm preview-email [confirmation|shipped|delivered|refunded]
 
 import { writeFileSync } from 'fs';
 import { join, dirname } from 'path';
@@ -11,6 +11,7 @@ import { render } from '@react-email/render';
 import { OrderConfirmationEmail } from '../src/emails/OrderConfirmation';
 import { OrderShippedEmail } from '../src/emails/OrderShipped';
 import { OrderDeliveredEmail } from '../src/emails/OrderDelivered';
+import { OrderRefundedEmail } from '../src/emails/OrderRefunded';
 import productsData from '../src/data/products.json' with { type: 'json' };
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -42,6 +43,14 @@ const templates = {
       carrier: { code: 'usps', trackingNumber: '9400111899223344556677', trackingUrl: 'https://tools.usps.com/go/TrackConfirmAction' },
     }),
   delivered: () => OrderDeliveredEmail({ firstName: 'Alex', itemLine: sampleItemLine }),
+  refunded: () =>
+    OrderRefundedEmail({
+      firstName: 'Alex',
+      amountRefunded: sampleVariant
+        ? new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(parseFloat(sampleVariant.price))
+        : '$35.00',
+      isFullRefund: true,
+    }),
 };
 
 if (!(template in templates)) {

--- a/src/emails/OrderRefunded.tsx
+++ b/src/emails/OrderRefunded.tsx
@@ -1,0 +1,73 @@
+import { Body, Container, Head, Heading, Hr, Html, Preview, Section, Text } from '@react-email/components';
+import { colors, fontMono, fontSans } from './theme';
+
+export interface OrderRefundedEmailProps {
+  firstName: string;
+  amountRefunded: string;
+  isFullRefund: boolean;
+}
+
+export function OrderRefundedEmail({ firstName, amountRefunded, isFullRefund }: OrderRefundedEmailProps) {
+  return (
+    <Html>
+      <Head />
+      <Preview>
+        {isFullRefund ? 'Your White Rabbit order has been refunded' : 'A refund has been issued for your White Rabbit order'}
+      </Preview>
+      <Body style={{ backgroundColor: colors.bg, fontFamily: fontSans, margin: 0, padding: '32px 0' }}>
+        <Container style={{ maxWidth: 480, margin: '0 auto', padding: '0 24px' }}>
+          <Text style={{ fontSize: 36, textAlign: 'center', margin: '0 0 8px' }}>🐰💸</Text>
+          <Heading
+            style={{
+              color: colors.accent,
+              fontFamily: fontMono,
+              fontSize: 26,
+              letterSpacing: 2,
+              textAlign: 'center',
+              margin: '0 0 24px',
+            }}
+          >
+            REFUNDED
+          </Heading>
+          <Text style={{ color: colors.text, fontSize: 16, lineHeight: '26px', textAlign: 'center', margin: 0 }}>
+            Hi {firstName}, {isFullRefund ? 'your order has been fully refunded.' : 'a partial refund has been issued for your order.'}
+          </Text>
+          <Section
+            style={{
+              backgroundColor: colors.card,
+              border: `1px solid ${colors.border}`,
+              borderRadius: 8,
+              padding: '20px',
+              margin: '24px 0',
+              textAlign: 'center',
+            }}
+          >
+            <Text
+              style={{
+                color: colors.textMuted,
+                fontSize: 11,
+                margin: '0 0 6px',
+                textTransform: 'uppercase',
+                letterSpacing: 1,
+              }}
+            >
+              {isFullRefund ? 'Amount Refunded' : 'Partial Refund'}
+            </Text>
+            <Text style={{ color: colors.text, fontFamily: fontMono, fontSize: 22, margin: 0 }}>
+              {amountRefunded}
+            </Text>
+          </Section>
+          <Text style={{ color: colors.textMuted, fontSize: 14, lineHeight: '22px', textAlign: 'center', margin: 0 }}>
+            It can take 5-10 business days to show up on your statement, depending on your bank.
+          </Text>
+          <Hr style={{ borderColor: colors.border, margin: '24px 0' }} />
+          <Text style={{ color: colors.textMuted, fontSize: 13, textAlign: 'center', margin: 0 }}>
+            Questions? Just reply to this email.
+          </Text>
+        </Container>
+      </Body>
+    </Html>
+  );
+}
+
+export default OrderRefundedEmail;

--- a/src/pages/api/stripe-webhook.ts
+++ b/src/pages/api/stripe-webhook.ts
@@ -5,6 +5,7 @@ import { createPrintifyOrder } from '../../lib/printful';
 import { sendEmail, sendResendEmail } from '../../lib/email';
 import { render } from '@react-email/render';
 import { OrderConfirmationEmail } from '../../emails/OrderConfirmation';
+import { OrderRefundedEmail } from '../../emails/OrderRefunded';
 import productsData from '../../data/products.json';
 
 export const prerender = false;
@@ -127,11 +128,14 @@ async function handleChargeRefunded(
     const firstName = (charge.billing_details?.name ?? 'there').split(' ')[0];
 
     try {
+      const html = await render(OrderRefundedEmail({ firstName, amountRefunded, isFullRefund }));
+
       await sendResendEmail(resendApiKey, {
         fromAddr: ORDER_FROM_ADDR,
         fromName: ORDER_FROM_NAME,
         to: email,
         subject: isFullRefund ? 'Your White Rabbit order has been refunded' : 'A refund has been issued for your White Rabbit order',
+        html,
         text: [
           `Hi ${firstName},`,
           ``,


### PR DESCRIPTION
## Summary
- Add `OrderRefundedEmail`, a branded react-email template matching the existing shipped/delivered/confirmation style (icon, heading, amount card, footer)
- Render it as HTML in `handleChargeRefunded` in the Stripe webhook, keeping the plain-text version as a fallback
- Add a `refunded` option to the local email preview script

## Test plan
- [x] Rendered locally via `pnpm preview-email refunded` and visually confirmed it matches the shipped/delivered look