### PR TITLE
fix: defer order fulfillment until payment actually clears

### DIFF
--- a/SHOP.md
+++ b/SHOP.md
@@ -17,10 +17,14 @@ flowchart TD
     B -- yes --> D{"event.type"}
     D -- "charge.dispute.created" --> E["handleChargeDisputeCreated\n(merchant-only alert)"]
     D -- "charge.refunded" --> F["handleChargeRefunded\n(branded customer email)"]
-    D -- "checkout.session.completed" --> G["Create Printify draft order\n+ customer + merchant emails"]
+    D -- "checkout.session.async_payment_failed" --> P["handleAsyncPaymentFailed\n(merchant-only alert, no order existed)"]
+    D -- "checkout.session.completed\nor async_payment_succeeded" --> Q{"payment_status\n== 'paid'?"}
+    Q -- no --> R["200 OK, defer\n(await async_payment_succeeded)"]
+    Q -- yes --> G["Create Printify draft order\n+ customer + merchant emails"]
     D -- anything else --> H["200 OK, ignored"]
     E --> Z["200 OK"]
     F --> Z
+    P --> Z
     G --> Z
 ```
 
@@ -44,6 +48,11 @@ sequenceDiagram
     Stripe->>Webhook: checkout.session.completed
     Webhook->>KV: get stripe_event:<id>
     KV-->>Webhook: not found
+    alt payment_status != 'paid' (async method still pending)
+        Webhook-->>Stripe: 200 OK (deferred, no order created)
+        Note over Stripe,Webhook: later, once it clears...
+        Stripe->>Webhook: checkout.session.async_payment_succeeded (payment_status now 'paid')
+    end
     Webhook->>Printify: createPrintifyOrder (draft, externalId=session.id)
     Printify-->>Webhook: draft order id
     Webhook->>KV: put stripe_event:<id> (7d TTL)
@@ -129,13 +138,18 @@ Merchant-only, and time-sensitive — Stripe auto-loses undisputed evidence dead
 
 1. Customer selects product/variant → `/api/checkout` creates a Stripe Checkout session
 2. Stripe redirects to hosted checkout; on success, fires a webhook to `/api/stripe-webhook`
-3. Webhook calls `createPrintifyOrder` in `src/lib/printful.ts`, which creates a **draft** order in Printify
-4. Webhook sends the customer an order-confirmation email via Resend, and a new-order notification to `whiterabbitwcs@gmail.com` (both best-effort — failure is logged but doesn't fail the webhook or retry the Printify order)
-5. Draft sits in the Printify dashboard for manual review — hit "Send to production" there to fulfill
+3. Webhook checks `session.payment_status` — if it's not yet `'paid'` (an asynchronous payment method like ACH bank debit was used), the webhook returns 200 without creating an order and waits for Stripe to fire `checkout.session.async_payment_succeeded` once the debit actually clears. Synchronous methods (card, Apple Pay, etc.) are already `'paid'` by the time `checkout.session.completed` fires, so this is a no-op for the common case.
+4. Once `payment_status` is `'paid'`, the webhook calls `createPrintifyOrder` in `src/lib/printful.ts`, which creates a **draft** order in Printify
+5. Webhook sends the customer an order-confirmation email via Resend, and a new-order notification to `whiterabbitwcs@gmail.com` (both best-effort — failure is logged but doesn't fail the webhook or retry the Printify order)
+6. Draft sits in the Printify dashboard for manual review — hit "Send to production" there to fulfill
+
+If the async payment method fails instead of clearing, Stripe fires `checkout.session.async_payment_failed`; `handleAsyncPaymentFailed` just notifies the merchant for visibility — no Printify order was ever created, so there's nothing to cancel.
 
 Printify itself never emails the customer here — this is a custom API integration, not a connected storefront, so Printify only talks to the merchant account. All customer-facing email is this app's responsibility.
 
 Orders are intentionally left as drafts (the `send_to_production` API call is omitted) so each order can be reviewed before Printify charges for fulfillment.
+
+**Requires a manual step**: the Stripe webhook endpoint must also be subscribed to `checkout.session.async_payment_succeeded` and `checkout.session.async_payment_failed`, not just `checkout.session.completed` — Dashboard → Developers → Webhooks → your endpoint. Without these, an order paid for via an async method never gets fulfilled at all (it's deferred forever).
 
 ## Shipping/Delivery Notification
 

--- a/src/pages/api/debug-calendar.json.ts
+++ b/src/pages/api/debug-calendar.json.ts
@@ -3,6 +3,10 @@ import type { APIContext } from "astro";
 export const prerender = false;
 
 export async function GET({ locals }: APIContext) {
+  if (!import.meta.env.DEV) {
+    return new Response("Not found", { status: 404 });
+  }
+
   const runtime = locals.runtime;
 
   // Try to get calendar ID from runtime env (Cloudflare) or import.meta.env (build time)

--- a/src/pages/api/stripe-webhook.ts
+++ b/src/pages/api/stripe-webhook.ts
@@ -97,6 +97,55 @@ async function handleChargeDisputeCreated(
   }
 }
 
+// checkout.session.completed fires as soon as the customer finishes the
+// checkout form -- for asynchronous payment methods (e.g. ACH bank debit)
+// that does NOT mean the payment cleared. Real settlement arrives later via
+// checkout.session.async_payment_succeeded/failed. This handler covers the
+// failure side: no Printify order was ever created for this session (see
+// the payment_status guard in POST below), so there's nothing to cancel --
+// just let the merchant know in case the customer asks what happened.
+async function handleAsyncPaymentFailed(
+  event: Stripe.Event,
+  kv: Env['SESSION'] | undefined,
+  merchantEmailBinding: { send: (msg: unknown) => Promise<void> } | undefined
+): Promise<void> {
+  const idempotencyKey = `stripe_event:${event.id}`;
+  if (kv) {
+    const already = await kv.get(idempotencyKey);
+    if (already) {
+      log(event.id, `Duplicate async-payment-failed event, skipping`);
+      return;
+    }
+  }
+
+  const session = event.data.object as Stripe.Checkout.Session;
+  log(event.id, `Async payment failed for session ${session.id} -- no order was created`);
+
+  try {
+    await sendEmail(merchantEmailBinding, {
+      fromAddr: ORDER_FROM_ADDR,
+      fromName: ORDER_FROM_NAME,
+      to: MERCHANT_TO,
+      subject: `Checkout payment failed (no order created)`,
+      text: [
+        `A customer completed checkout, but their payment method (likely a bank debit) failed to clear.`,
+        ``,
+        `No Printify order was created for this session -- there's nothing to cancel.`,
+        ``,
+        `Session: ${session.id}`,
+        `Customer: ${session.customer_details?.email ?? 'unknown'}`,
+      ].join('\n'),
+    });
+    log(event.id, `Async-payment-failed notification sent for session ${session.id}`);
+  } catch (err) {
+    logError(event.id, `Async-payment-failed notification failed for session ${session.id}`, err);
+  }
+
+  if (kv) {
+    await kv.put(idempotencyKey, session.id, { expirationTtl: 604800 });
+  }
+}
+
 // Refunds are always initiated by the merchant (via Stripe dashboard or
 // API), so there's no equivalent "merchant notification" here -- whoever
 // issued the refund already knows. This only tells the customer.
@@ -211,7 +260,12 @@ export async function POST({ request, locals }: APIContext) {
     return new Response('OK', { status: 200 });
   }
 
-  if (event.type !== 'checkout.session.completed') {
+  if (event.type === 'checkout.session.async_payment_failed') {
+    await handleAsyncPaymentFailed(event, kv, merchantEmailBinding);
+    return new Response('OK', { status: 200 });
+  }
+
+  if (event.type !== 'checkout.session.completed' && event.type !== 'checkout.session.async_payment_succeeded') {
     return new Response('OK', { status: 200 });
   }
 
@@ -228,6 +282,17 @@ export async function POST({ request, locals }: APIContext) {
   }
 
   const session = event.data.object as Stripe.Checkout.Session;
+
+  // checkout.session.completed fires the instant the customer submits the
+  // form, before an async payment method (ACH, etc.) has actually cleared.
+  // Fulfilling here regardless would ship product against a payment that
+  // can still fail. Defer: this same session re-arrives, with payment_status
+  // now 'paid', as checkout.session.async_payment_succeeded once it clears.
+  if (session.payment_status !== 'paid') {
+    log(event.id, `session=${session.id} payment_status=${session.payment_status} — awaiting async payment confirmation, deferring fulfillment`);
+    return new Response('OK', { status: 200 });
+  }
+
   const productId = session.metadata?.printify_product_id ?? '';
   const variantId = Number(session.metadata?.printify_variant_id);
   const quantity = Number(session.metadata?.quantity ?? 1);

--- a/src/pages/api/stripe-webhook.ts
+++ b/src/pages/api/stripe-webhook.ts
@@ -119,7 +119,10 @@ async function handleAsyncPaymentFailed(
   }
 
   const session = event.data.object as Stripe.Checkout.Session;
-  log(event.id, `Async payment failed for session ${session.id} -- no order was created`);
+  log(
+    event.id,
+    `Async payment failed for session ${session.id} email=${session.customer_details?.email ?? 'unknown'} -- no order was created`
+  );
 
   try {
     await sendEmail(merchantEmailBinding, {
@@ -248,7 +251,15 @@ export async function POST({ request, locals }: APIContext) {
     return new Response('Invalid request', { status: 400 });
   }
 
-  log(event.id, `Received event type=${event.type}`);
+  // checkout.session.completed/async_payment_succeeded/async_payment_failed
+  // all carry the same session id -- logging it on this first line (before
+  // any type-specific branching) means every log for one checkout, across
+  // however many of those events Stripe ends up sending, can be found by
+  // grepping for the session id alone, not just the (different) event id.
+  const eventSessionId = event.type.startsWith('checkout.session.')
+    ? (event.data.object as Stripe.Checkout.Session).id
+    : undefined;
+  log(event.id, `Received event type=${event.type}${eventSessionId ? ` session=${eventSessionId}` : ''}`);
 
   if (event.type === 'charge.dispute.created') {
     await handleChargeDisputeCreated(event, kv, merchantEmailBinding, stripeKey);
@@ -288,8 +299,13 @@ export async function POST({ request, locals }: APIContext) {
   // Fulfilling here regardless would ship product against a payment that
   // can still fail. Defer: this same session re-arrives, with payment_status
   // now 'paid', as checkout.session.async_payment_succeeded once it clears.
+  const customerEmailForLog = session.customer_details?.email ?? 'unknown';
+
   if (session.payment_status !== 'paid') {
-    log(event.id, `session=${session.id} payment_status=${session.payment_status} — awaiting async payment confirmation, deferring fulfillment`);
+    log(
+      event.id,
+      `session=${session.id} email=${customerEmailForLog} payment_status=${session.payment_status} — awaiting async payment confirmation, deferring fulfillment`
+    );
     return new Response('OK', { status: 200 });
   }
 
@@ -297,7 +313,10 @@ export async function POST({ request, locals }: APIContext) {
   const variantId = Number(session.metadata?.printify_variant_id);
   const quantity = Number(session.metadata?.quantity ?? 1);
 
-  log(event.id, `session=${session.id} productId=${productId} variantId=${variantId} quantity=${quantity}`);
+  log(
+    event.id,
+    `session=${session.id} email=${customerEmailForLog} via=${event.type} productId=${productId} variantId=${variantId} quantity=${quantity}`
+  );
 
   if (!productId || !variantId) {
     logError(event.id, `Missing printify metadata on session ${session.id}: ${JSON.stringify(session.metadata)}`);


### PR DESCRIPTION
## Summary
- `checkout.session.completed` fires as soon as a customer finishes checkout, not once payment settles. For async payment methods (e.g. ACH), `payment_status` can still be `'unpaid'` at that point — fulfilling immediately risked creating a Printify order and shipping product against a payment that later fails.
- The webhook now checks `session.payment_status` and defers fulfillment until `checkout.session.async_payment_succeeded` fires (payment confirmed). `checkout.session.async_payment_failed` notifies the merchant for visibility — no order was ever created, so there's nothing to cancel.
- Synchronous methods (card, Apple Pay, etc.) are unaffected — `payment_status` is already `'paid'` by the time `checkout.session.completed` fires, so this is a no-op for the common case.
- Restricted `/api/debug-calendar.json` to local dev only (`import.meta.env.DEV` gate) — it had no auth and was leaking the Google Calendar ID plus raw error stacks to any visitor in production.
- Updated `SHOP.md`'s webhook diagrams and docs to reflect the new event routing and the manual Stripe Dashboard step required (subscribe to `checkout.session.async_payment_succeeded` and `checkout.session.async_payment_failed`).

## Test plan
- [ ] Subscribe the Stripe webhook endpoint to `checkout.session.async_payment_succeeded` and `checkout.session.async_payment_failed` in Dashboard → Developers → Webhooks
- [ ] Verify a normal card checkout still fulfills immediately (no regression)
- [ ] If possible, test with a Stripe test-mode ACH payment method to confirm fulfillment defers until `async_payment_succeeded`
- [x] Confirmed `/api/debug-calendar.json` returns 404 outside local dev